### PR TITLE
Bump Catch2 version tag on fetch

### DIFF
--- a/cmake/Catch2.cmake
+++ b/cmake/Catch2.cmake
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   catch2
   GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-  GIT_TAG        "v2.13.4"
+  GIT_TAG        "v2.13.5"
 )
 
 FetchContent_MakeAvailable(catch2)


### PR DESCRIPTION
The current version of catch2 fetched raises an error (when building the `tc_test.exe` target at least). This fixes the issue per https://github.com/catchorg/Catch2/issues/2421.