### PR TITLE
Adds inline for functions & Bugfix in (de-)serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Prerequisites
 *.d
 
+# Temporary files
+.cache
+.idea
+
 # Compiled Object files
 *.slo
 *.lo

--- a/include/nwgraph/adjacency.hpp
+++ b/include/nwgraph/adjacency.hpp
@@ -177,13 +177,13 @@ template <int idx, typename... Attributes>
 using adjacency = index_adjacency<idx, default_index_t, default_vertex_id_type, Attributes...>;
 
 template <int idx, edge_list_graph edge_list_t>
-auto make_adjacency(edge_list_t& el) {
+inline auto make_adjacency(edge_list_t& el) {
   return adjacency<idx>(el);
 }
 
 
 template <int idx, edge_list_c edge_list_t, std::unsigned_integral u_integral, class ExecutionPolicy = std::execution::parallel_unsequenced_policy>
-auto make_adjacency(edge_list_t& el, u_integral n, directedness edge_directedness = directedness::directed, ExecutionPolicy&& policy = {}) {
+inline auto make_adjacency(edge_list_t& el, u_integral n, directedness edge_directedness = directedness::directed, ExecutionPolicy&& policy = {}) {
   adjacency<idx> adj(n);
   fill<idx>(el, adj, edge_directedness, policy);
   return adj;
@@ -300,13 +300,13 @@ template <int idx, typename... Attributes>
 using biadjacency = index_biadjacency<idx, default_index_t, default_vertex_id_type, Attributes...>;
 
 template <int idx, edge_list_graph edge_list_t>
-auto make_biadjacency(edge_list_t& el) {
+inline auto make_biadjacency(edge_list_t& el) {
   return biadjacency<idx>(el);
 }
 
 
 template <int idx, edge_list_c edge_list_t, std::unsigned_integral u_integral, class ExecutionPolicy = std::execution::parallel_unsequenced_policy>
-auto make_biadjacency(edge_list_t& el, u_integral n0, u_integral n1, directedness edge_directedness = directedness::directed, ExecutionPolicy&& policy = {}) {
+inline auto make_biadjacency(edge_list_t& el, u_integral n0, u_integral n1, directedness edge_directedness = directedness::directed, ExecutionPolicy&& policy = {}) {
   biadjacency<idx> adj(n0, n1);
   fill_biadjacency<idx>(el, adj, policy);
   return adj;
@@ -319,39 +319,39 @@ auto make_biadjacency(edge_list_t& el, u_integral n0, u_integral n1, directednes
 //}
 //index_adjacency num_vertices CPO
 template <int idx, std::unsigned_integral index_type, std::unsigned_integral vertex_id_type, typename... Attributes>
-auto tag_invoke(const num_vertices_tag, const index_adjacency<idx, index_type, vertex_id_type, Attributes...>& g) {
+inline auto tag_invoke(const num_vertices_tag, const index_adjacency<idx, index_type, vertex_id_type, Attributes...>& g) {
   return g.num_vertices()[0];
 }
 //index_adjacency degree CPO
 template <int idx, std::unsigned_integral index_type, std::unsigned_integral vertex_id_type, std::unsigned_integral lookup_type, typename... Attributes>
-auto tag_invoke(const degree_tag, const index_adjacency<idx, index_type, vertex_id_type, Attributes...>& g, lookup_type i) {
+inline auto tag_invoke(const degree_tag, const index_adjacency<idx, index_type, vertex_id_type, Attributes...>& g, lookup_type i) {
   return g[i].size();
 }
 //index_adjacency degree CPO
 template <int idx, std::unsigned_integral index_type, std::unsigned_integral vertex_id_type, typename... Attributes>
-auto tag_invoke(const degree_tag, const index_adjacency<idx, index_type, vertex_id_type, Attributes...>& g,
+inline auto tag_invoke(const degree_tag, const index_adjacency<idx, index_type, vertex_id_type, Attributes...>& g,
                 const typename index_adjacency<idx, index_type, vertex_id_type, Attributes...>::sub_view& v) {
   return v.size();
 }
 //index_biadjacency num_vertices CPO
 template <int idx, std::unsigned_integral index_type, std::unsigned_integral vertex_id_type, typename... Attributes>
-auto tag_invoke(const num_vertices_tag, const index_biadjacency<idx, index_type, vertex_id_type, Attributes...>& g, int jdx = 0) {
+inline auto tag_invoke(const num_vertices_tag, const index_biadjacency<idx, index_type, vertex_id_type, Attributes...>& g, int jdx = 0) {
   return g.num_vertices()[jdx];
 }
 //index_biadjacency degree CPO
 template <int idx, std::unsigned_integral index_type, std::unsigned_integral vertex_id_type, std::unsigned_integral lookup_type, typename... Attributes>
-auto tag_invoke(const degree_tag, const index_biadjacency<idx, index_type, vertex_id_type, Attributes...>& g, lookup_type i) {
+inline auto tag_invoke(const degree_tag, const index_biadjacency<idx, index_type, vertex_id_type, Attributes...>& g, lookup_type i) {
   return g[i].size();
 }
 //index_biadjacency degree CPO
 template <int idx, std::unsigned_integral index_type, std::unsigned_integral vertex_id_type, typename... Attributes>
-auto tag_invoke(const degree_tag, const index_biadjacency<idx, index_type, vertex_id_type, Attributes...>& g,
+inline auto tag_invoke(const degree_tag, const index_biadjacency<idx, index_type, vertex_id_type, Attributes...>& g,
                 const typename index_biadjacency<idx, index_type, vertex_id_type, Attributes...>::sub_view& v) {
   return v.size();
 }
 //degree CPO
 template <class Iterator>
-auto tag_invoke(const degree_tag, const splittable_range_adaptor<Iterator>& n) {
+inline auto tag_invoke(const degree_tag, const splittable_range_adaptor<Iterator>& n) {
   return n.size();
 }
 

--- a/include/nwgraph/algorithms/betweenness_centrality.hpp
+++ b/include/nwgraph/algorithms/betweenness_centrality.hpp
@@ -57,8 +57,8 @@ namespace nw {
 namespace graph {
 
 template <class score_t, class accum_t, adjacency_list_graph Graph>
-bool BCVerifier(const Graph& g, std::vector<typename graph_traits<Graph>::vertex_id_type>& trial_sources,
-                std::vector<score_t>& scores_to_test, bool normalize = true) {
+inline bool BCVerifier(const Graph& g, std::vector<typename graph_traits<Graph>::vertex_id_type>& trial_sources,
+                       std::vector<score_t>& scores_to_test, bool normalize = true) {
   using vertex_id_type = typename graph_traits<Graph>::vertex_id_type;
 
   std::vector<score_t> scores(num_vertices(g), 0);
@@ -139,7 +139,7 @@ bool BCVerifier(const Graph& g, std::vector<typename graph_traits<Graph>::vertex
  * @return Vector of centrality for each vertex.
  */
 template <adjacency_list_graph Graph, typename score_t = float, typename accum_t = size_t>
-std::vector<score_t> brandes_bc(const Graph& G, bool normalize = true) {
+inline std::vector<score_t> brandes_bc(const Graph& G, bool normalize = true) {
   using vertex_id_type = typename Graph::vertex_id_type;
 
   size_t               n_vtx = num_vertices(G);
@@ -217,8 +217,8 @@ std::vector<score_t> brandes_bc(const Graph& G, bool normalize = true) {
  */
 template <class score_t, class accum_t, adjacency_list_graph Graph, class OuterExecutionPolicy = std::execution::parallel_unsequenced_policy,
           class InnerExecutionPolicy = std::execution::parallel_unsequenced_policy>
-auto brandes_bc(const Graph& graph, const std::vector<typename Graph::vertex_id_type>& sources, int threads,
-                OuterExecutionPolicy&& outer_policy = {}, InnerExecutionPolicy&& inner_policy = {}, bool normalize = true) {
+inline auto brandes_bc(const Graph& graph, const std::vector<typename Graph::vertex_id_type>& sources, int threads,
+                       OuterExecutionPolicy&& outer_policy = {}, InnerExecutionPolicy&& inner_policy = {}, bool normalize = true) {
   using vertex_id_type = typename Graph::vertex_id_type;
 
   vertex_id_type       N     = num_vertices(graph);
@@ -345,8 +345,8 @@ auto brandes_bc(const Graph& graph, const std::vector<typename Graph::vertex_id_
  */
 template <class score_t, class accum_t, adjacency_list_graph Graph, class OuterExecutionPolicy = std::execution::parallel_unsequenced_policy,
           class InnerExecutionPolicy = std::execution::parallel_unsequenced_policy>
-auto exact_brandes_bc(const Graph& graph, int threads,
-                OuterExecutionPolicy&& outer_policy = {}, InnerExecutionPolicy&& inner_policy = {}, bool normalize = true) {
+inline auto exact_brandes_bc(const Graph& graph, int threads,
+                             OuterExecutionPolicy&& outer_policy = {}, InnerExecutionPolicy&& inner_policy = {}, bool normalize = true) {
   using vertex_id_type = typename Graph::vertex_id_type;
   vertex_id_type       N     = num_vertices(graph);
   std::vector<vertex_id_type> sources(N);

--- a/include/nwgraph/algorithms/bfs.hpp
+++ b/include/nwgraph/algorithms/bfs.hpp
@@ -42,7 +42,7 @@ namespace nw {
 namespace graph {
   
 template <adjacency_list_graph Graph, adjacency_list_graph GraphT>
-bool BFSVerifier(const Graph& g, GraphT& g_t, vertex_id_t<Graph> source, std::vector<vertex_id_t<Graph>>& parent) {
+inline bool BFSVerifier(const Graph& g, GraphT& g_t, vertex_id_t<Graph> source, std::vector<vertex_id_t<Graph>>& parent) {
   using vertex_id_type = vertex_id_t<Graph>;
 
   std::vector<vertex_id_type> depth(num_vertices(g), std::numeric_limits<vertex_id_type>::max());
@@ -108,7 +108,7 @@ bool BFSVerifier(const Graph& g, GraphT& g_t, vertex_id_t<Graph> source, std::ve
    * @return The parent list.
    */
 template <adjacency_list_graph Graph>
-auto bfs(const Graph& graph, vertex_id_t<Graph> root) {
+inline auto bfs(const Graph& graph, vertex_id_t<Graph> root) {
   using vertex_id_type = vertex_id_t<Graph>;
 
   std::deque<vertex_id_type>  q1, q2;
@@ -158,8 +158,8 @@ auto bfs(const Graph& graph, vertex_id_t<Graph> root) {
  * @return The parent list.
  */
 template <adjacency_list_graph OutGraph, adjacency_list_graph InGraph>
-[[gnu::noinline]] auto bfs(const OutGraph& out_graph, const InGraph& in_graph, vertex_id_t<OutGraph> root, int num_bins = 32, int alpha = 15,
-                           int beta = 18) {
+[[gnu::noinline]] static auto bfs(const OutGraph& out_graph, const InGraph& in_graph, vertex_id_t<OutGraph> root,
+                                  int num_bins = 32, int alpha = 15, int beta = 18) {
 
   using vertex_id_type = vertex_id_t<OutGraph>;
 

--- a/include/nwgraph/algorithms/boykov_kolmogorov.hpp
+++ b/include/nwgraph/algorithms/boykov_kolmogorov.hpp
@@ -39,7 +39,7 @@ enum class tree_mem : bool { source = false, term = true };
  * @param cap Vector of edge capacities.
  */
 template <typename Graph>
-std::tuple<double, std::vector<tree_mem>> bk_maxflow(const Graph& A, std::vector<double>& cap) {
+inline std::tuple<double, std::vector<tree_mem>> bk_maxflow(const Graph& A, std::vector<double>& cap) {
   // std::clock_t start;
   // double grow = 0;
   // double augment = 0;

--- a/include/nwgraph/algorithms/dag_based_mis.hpp
+++ b/include/nwgraph/algorithms/dag_based_mis.hpp
@@ -34,7 +34,7 @@ namespace graph {
  * @param mis (out) Boolean vector indicating whether corresponding vertex is in the maximal independent set.
  */
 template <adjacency_list_graph Graph>
-void dag_based_mis(Graph& A, std::vector<bool>& mis) {
+inline void dag_based_mis(Graph& A, std::vector<bool>& mis) {
   size_t N = A.size();
 #ifdef PRINT_DEBUG
   std::cout << "size: " << N << std::endl;

--- a/include/nwgraph/algorithms/delta_stepping.hpp
+++ b/include/nwgraph/algorithms/delta_stepping.hpp
@@ -107,7 +107,7 @@ auto delta_stepping_m1(
  * @param weight Function to compute weight of an edge.
  */
 template <class distance_t, adjacency_list_graph Graph, class T, class Weight>
-auto delta_stepping(
+inline auto delta_stepping(
     const Graph& graph, vertex_id_t<Graph> source, T delta, Weight weight = [](auto& e) -> auto& { return std::get<1>(e); }) {
   using Id = vertex_id_t<Graph>;
   std::vector<distance_t>      tdist(num_vertices(graph), std::numeric_limits<distance_t>::max());
@@ -170,7 +170,7 @@ auto delta_stepping(
  * @param delta The delta parameter for the algorithm.
  */
 template <class distance_t, adjacency_list_graph Graph, class T>
-auto delta_stepping(const Graph& graph, vertex_id_t<Graph> source, T delta) {
+inline auto delta_stepping(const Graph& graph, vertex_id_t<Graph> source, T delta) {
   using Id = vertex_id_t<Graph>;
   tbb::queuing_mutex                                 lock;
   std::atomic<std::size_t>                           size = 1;

--- a/include/nwgraph/algorithms/dijkstra.hpp
+++ b/include/nwgraph/algorithms/dijkstra.hpp
@@ -41,7 +41,7 @@ namespace graph {
  * @return Vector of distances from the starting node for each vertex in the graph.
  */
 template <typename Distance, adjacency_list_graph Graph>
-std::vector<Distance> dijkstra_er(const Graph& graph, vertex_id_t<Graph> source) {
+inline std::vector<Distance> dijkstra_er(const Graph& graph, vertex_id_t<Graph> source) {
   using vertex_id_type = vertex_id_t<Graph>;
 
   size_t N(graph.end() - graph.begin());
@@ -80,7 +80,7 @@ std::vector<Distance> dijkstra_er(const Graph& graph, vertex_id_t<Graph> source)
 template <
     typename Distance, adjacency_list_graph Graph,
     std::invocable<inner_value_t<Graph>> Weight = std::function<std::tuple_element_t<1, inner_value_t<Graph>>(const inner_value_t<Graph>&)>>
-auto dijkstra(
+inline auto dijkstra(
     const Graph& graph, vertex_id_t<Graph> source, Weight weight = [](auto& e) { return std::get<1>(e); }) {
   using vertex_id_type = vertex_id_t<Graph>;
 

--- a/include/nwgraph/algorithms/jaccard.hpp
+++ b/include/nwgraph/algorithms/jaccard.hpp
@@ -43,7 +43,7 @@ namespace graph {
  * @return size_t Jaccard similarity score.
  */
 template <adjacency_list_graph GraphT, typename Weight>
-size_t jaccard_similarity(GraphT& G, Weight weight) {
+inline size_t jaccard_similarity(GraphT& G, Weight weight) {
   size_t ctr = 0;
 
   for (size_t u = 0; u < num_vertices(G); ++u) {

--- a/include/nwgraph/algorithms/jones_plassmann_coloring.hpp
+++ b/include/nwgraph/algorithms/jones_plassmann_coloring.hpp
@@ -34,7 +34,7 @@ namespace graph {
  * @param colors The array of colors of each vertex.
  */
 template <adjacency_list_graph Graph>
-void jones_plassmann_coloring(Graph& A, std::vector<size_t>& colors) {
+inline void jones_plassmann_coloring(Graph& A, std::vector<size_t>& colors) {
   size_t N = num_vertices(A);
   //init every nodes' color to 0
   std::fill(colors.begin(), colors.end(), 0);

--- a/include/nwgraph/algorithms/k_core.hpp
+++ b/include/nwgraph/algorithms/k_core.hpp
@@ -50,7 +50,7 @@ using Unordered_map = std::unordered_map<Neighbors, bool, pair_hash>;
  * @param y The other endpoint of an edge.
  * @return Neighbors of an edge such that 0th element in the pair is smaller than 1th element.
  */
-Neighbors make_my_pair(default_vertex_id_type x, default_vertex_id_type y) {
+inline Neighbors make_my_pair(default_vertex_id_type x, default_vertex_id_type y) {
   if (x < y) return std::make_pair(x, y);
   return std::make_pair(y, x);
 }
@@ -64,7 +64,7 @@ Neighbors make_my_pair(default_vertex_id_type x, default_vertex_id_type y) {
  * @return std::tuple<Unordered_map, size_t> of an Unordered_map (k core), and the number of vertices in k core.
  */
 template <adjacency_list_graph Graph>
-std::tuple<Unordered_map, size_t> k_core(const Graph& A, int k) {
+inline std::tuple<Unordered_map, size_t> k_core(const Graph& A, int k) {
   Unordered_map filter;
 
   size_t                          n_vtx     = A.size();

--- a/include/nwgraph/algorithms/kruskal.hpp
+++ b/include/nwgraph/algorithms/kruskal.hpp
@@ -36,7 +36,7 @@ namespace graph {
  * @return EdgeListT output edge list of the minimum spanning tree
  */
 template <edge_list_graph EdgeListT>
-EdgeListT kruskal(EdgeListT& E) {
+inline EdgeListT kruskal(EdgeListT& E) {
   return kruskal(E, [](auto t1, auto t2) { return std::get<2>(t1) < std::get<2>(t2); });
 }
 /**
@@ -49,7 +49,7 @@ EdgeListT kruskal(EdgeListT& E) {
  * @return EdgeListT output edge list of the minimum spanning tree
  */
 template <edge_list_graph EdgeListT, typename Compare>
-EdgeListT kruskal(EdgeListT& E, Compare comp) {
+inline EdgeListT kruskal(EdgeListT& E, Compare comp) {
   size_t    n_vtx = E.size();
   EdgeListT T(n_vtx);
   std::sort(E.begin(), E.end(), comp);

--- a/include/nwgraph/algorithms/max_flow.hpp
+++ b/include/nwgraph/algorithms/max_flow.hpp
@@ -37,7 +37,7 @@ enum class default_dict { capacity_idx = 1, flow_idx = 2 };
  * @return auto the Idx-the element in the backedge
  */
 template <size_t Idx, typename Edge>
-auto backedge_property(Edge edge) {
+inline auto backedge_property(Edge edge) {
   return std::get<Idx>(edge);
 }
 
@@ -54,7 +54,7 @@ auto backedge_property(Edge edge) {
  * @return flowtype the max flow value
  */
 template <typename Dict = default_dict, typename flowtype = double, adjacency_list_graph Graph>
-flowtype max_flow(const Graph& A, vertex_id_type source, vertex_id_type sink, size_t max_iters = DEFAULT_MAX) {
+inline flowtype max_flow(const Graph& A, vertex_id_type source, vertex_id_type sink, size_t max_iters = DEFAULT_MAX) {
   struct tree_edge {
     flowtype* capacity;
     flowtype* flow;

--- a/include/nwgraph/algorithms/maximal_independent_set.hpp
+++ b/include/nwgraph/algorithms/maximal_independent_set.hpp
@@ -30,7 +30,7 @@ namespace graph {
  * @param mis the vertices in the maximal independent set
  */
 template <adjacency_list_graph Graph>
-void maximal_independent_set(const Graph& A, std::vector<size_t>& mis) {
+inline void maximal_independent_set(const Graph& A, std::vector<size_t>& mis) {
   using vertex_id_type = vertex_id_t<Graph>;
   size_t            N = A.size();
   std::vector<bool> removedVertices(N);

--- a/include/nwgraph/algorithms/page_rank.hpp
+++ b/include/nwgraph/algorithms/page_rank.hpp
@@ -58,7 +58,7 @@ constexpr auto trace = [](auto iter, auto error, auto time, auto max) {
  * @return auto a tuple of time duration and the result of the op (optional)
  */
 template <class Op>
-auto time_op(Op&& op) {
+inline auto time_op(Op&& op) {
   if constexpr (std::is_void_v<decltype(op())>) {
     auto start = std::chrono::high_resolution_clock::now();
     op();
@@ -87,8 +87,8 @@ auto time_op(Op&& op) {
  * @param num_threads number of threads
  */
 template <adjacency_list_graph Graph, typename Real>
-[[gnu::noinline]] void page_rank(const Graph& graph, const std::vector<typename Graph::vertex_id_type>& degrees,
-                                     std::vector<Real>& page_rank, Real damping_factor, Real threshold, size_t max_iters, size_t num_threads) {
+[[gnu::noinline]] static void page_rank(const Graph& graph, const std::vector<typename Graph::vertex_id_type>& degrees,
+                                        std::vector<Real>& page_rank, Real damping_factor, Real threshold, size_t max_iters, size_t num_threads) {
   std::size_t N          = graph.size();
   Real        init_score = 1.0 / N;
   Real        base_score = (1.0 - damping_factor) / N;

--- a/include/nwgraph/algorithms/prim.hpp
+++ b/include/nwgraph/algorithms/prim.hpp
@@ -35,7 +35,7 @@ namespace graph {
  * @return std::vector<vertex_id_t<Graph>>, the predecessor list (the MST).
  */
 template <adjacency_list_graph Graph, class Distance, class Weight>
-std::vector<vertex_id_t<Graph>> prim(const Graph& graph, vertex_id_t<Graph> source, Weight&& weight) {
+inline std::vector<vertex_id_t<Graph>> prim(const Graph& graph, vertex_id_t<Graph> source, Weight&& weight) {
 
   using vertex_id_type = vertex_id_t<Graph>;
 

--- a/include/nwgraph/algorithms/spMatspMat.hpp
+++ b/include/nwgraph/algorithms/spMatspMat.hpp
@@ -51,7 +51,7 @@ namespace graph {
  */
 template <typename ScalarT, adjacency_list_graph LGraphT, adjacency_list_graph RGraphT, typename MapOpT = std::multiplies<ScalarT>,
           typename ReduceOpT = std::plus<ScalarT>>
-edge_list<directedness::directed, ScalarT> spMatspMat(const LGraphT& A, const RGraphT& B) {
+inline edge_list<directedness::directed, ScalarT> spMatspMat(const LGraphT& A, const RGraphT& B) {
   edge_list<directedness::directed, ScalarT> edges(0);
   edges.open_for_push_back();
 
@@ -103,7 +103,7 @@ edge_list<directedness::directed, ScalarT> spMatspMat(const LGraphT& A, const RG
  * @param map map operation
  */
 template <class InputIt1, class InputIt2, class Output, class Compare, class Map>
-void set_ewise_intersection(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Output& container, Compare comp, Map map) {
+inline void set_ewise_intersection(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Output& container, Compare comp, Map map) {
   while (first1 != last1 && first2 != last2) {
     if (comp(*first1, *first2)) {
       ++first1;
@@ -134,7 +134,7 @@ void set_ewise_intersection(InputIt1 first1, InputIt1 last1, InputIt2 first2, In
  */
 template <typename ScalarT, adjacency_list_graph LGraphT, adjacency_list_graph RGraphT, typename MapOpT = std::multiplies<ScalarT>,
           typename ReduceOpT = std::plus<ScalarT>>
-edge_list<directedness::directed, ScalarT> spMatspMatT(LGraphT& A, RGraphT& BT) {
+inline edge_list<directedness::directed, ScalarT> spMatspMatT(LGraphT& A, RGraphT& BT) {
   std::vector<ScalarT> products;
 
   using vertex_id_type = vertex_id_t<LGraphT>;

--- a/include/nwgraph/algorithms/triangle_count.hpp
+++ b/include/nwgraph/algorithms/triangle_count.hpp
@@ -42,7 +42,7 @@ namespace graph {
  * @return size_t the number of triangles
  */
 template <adjacency_list_graph GraphT>
-size_t triangle_count(const GraphT& A) {
+inline size_t triangle_count(const GraphT& A) {
   size_t triangles = 0;
   auto   first     = A.begin();
   auto   last      = A.end();
@@ -68,7 +68,7 @@ size_t triangle_count(const GraphT& A) {
 ///
 /// @return             The += reduced total of counted triangles.
 template <class Op>
-std::size_t triangle_count_async(std::size_t threads, Op&& op) {
+inline std::size_t triangle_count_async(std::size_t threads, Op&& op) {
   // Launch the workers.
   std::vector<std::future<size_t>> futures(threads);
   for (std::size_t tid = 0; tid < threads; ++tid) {
@@ -94,7 +94,7 @@ std::size_t triangle_count_async(std::size_t threads, Op&& op) {
  * @return std::size_t number of triangles
  */
 template <adjacency_list_graph Graph>
-[[gnu::noinline]] std::size_t triangle_count(const Graph& G, std::size_t threads) {
+[[gnu::noinline]] static std::size_t triangle_count(const Graph& G, std::size_t threads) {
   auto first = G.begin();
   auto last = G.end();
   return triangle_count_async(threads, [&](std::size_t tid) {

--- a/include/nwgraph/build.hpp
+++ b/include/nwgraph/build.hpp
@@ -44,18 +44,18 @@ namespace graph {
 using default_execution_policy = std::execution::parallel_unsequenced_policy;
 
 template <int idx, edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-void sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
+inline void sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
   std::sort(std::execution::seq, el.begin(), el.end(),
             [](const auto& a, const auto& b) -> bool { return (std::get<idx>(a) < std::get<idx>(b)); });
 }
 
 template <int idx, edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-void stable_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
+inline void stable_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
   std::stable_sort(policy, el.begin(), el.end(), [](const auto& a, const auto& b) -> bool { return (std::get<idx>(a) < std::get<idx>(b)); });
 }
 
 template <int idx, edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-void lexical_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
+inline void lexical_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
   static_assert(std::is_same_v<decltype(el.begin()), typename edge_list_t::iterator>);
 
   const int jdx = (idx + 1) % 2;
@@ -70,7 +70,7 @@ void lexical_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
 }
 
 template <int idx, edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-void lexical_stable_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
+inline void lexical_stable_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
 
   const int jdx = (idx + 1) % 2;
 
@@ -81,13 +81,13 @@ void lexical_stable_sort_by(edge_list_t& el, ExecutionPolicy&& policy = {}) {
 
 
 template <adjacency_list_graph adjacency_t, typename... Ts>
-auto push_back_fill_helper(adjacency_t& cs, std::tuple<Ts...> const& theTuple) {
+inline auto push_back_fill_helper(adjacency_t& cs, std::tuple<Ts...> const& theTuple) {
 
   std::apply([&](Ts const&... args) { cs.push_back(args...); }, theTuple);
 }
 
 template <edge_list_c edge_list_t, adjacency_list_graph adjacency_t>
-void push_back_fill(edge_list_t& el, adjacency_t& cs) {
+inline void push_back_fill(edge_list_t& el, adjacency_t& cs) {
   cs.open_for_push_back();
 
   std::for_each(el.begin(), el.end(), [&](auto&& elt) { push_back_fill_helper(cs, elt); });
@@ -99,7 +99,7 @@ void push_back_fill(edge_list_t& el, adjacency_t& cs) {
  * Fill a plain or non-plain graph from edge list
  */
 template <edge_list_graph EdgeList, adjacency_list_graph Adjacency>
-void push_back_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, size_t idx) {
+inline void push_back_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, size_t idx) {
   const size_t jdx = (idx + 1) % 2;
 
   for (auto&& e : edge_list) {
@@ -118,7 +118,7 @@ void push_back_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, si
 }
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adj_list_t>
-auto fill_adj_list(edge_list_t& el, adj_list_t& al) {
+inline auto fill_adj_list(edge_list_t& el, adj_list_t& al) {
   size_t num_edges = 0;
 
   al.open_for_push_back();
@@ -140,7 +140,7 @@ auto fill_adj_list(edge_list_t& el, adj_list_t& al) {
 
 
 template <class Vector1, class Vector2, class Perm>
-void permute(const Vector1& vec1, Vector2& vec2, const Perm& perm) {
+inline void permute(const Vector1& vec1, Vector2& vec2, const Perm& perm) {
   tbb::parallel_for(tbb::blocked_range(0ul, perm.size()), [&](auto&& r) {
     for (auto i = r.begin(), e = r.end(); i != e; ++i) {
       vec2[i] = vec1[perm[i]];
@@ -149,30 +149,30 @@ void permute(const Vector1& vec1, Vector2& vec2, const Perm& perm) {
 }
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class Perm, size_t... Is>
-void permute_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, const Perm& perm) {
+inline void permute_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, const Perm& perm) {
   (..., (permute(std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(el)), std::get<Is + 1>(cs.to_be_indexed_), perm)));
 }
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class Perm, size_t... Is>
-void permute_helper_all(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, const Perm& perm) {
+inline void permute_helper_all(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, const Perm& perm) {
   (..., (permute(std::get<Is + 1>(dynamic_cast<typename edge_list_t::base&>(el)), std::get<Is>(cs.to_be_indexed_), perm)));
 }
 
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class T, class Perm, size_t... Is>
-void permute_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, T& Tmp, Perm& perm) {
+inline void permute_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, T& Tmp, Perm& perm) {
   (..., (permute(std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(Tmp)), std::get<Is + 1>(cs.to_be_indexed_), perm)));
 }
 
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class ExecutionPolicy = default_execution_policy, size_t... Is>
-void fill_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, ExecutionPolicy&& policy = {}) {
+inline void fill_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, ExecutionPolicy&& policy = {}) {
   (..., (std::copy(policy, std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(el)).begin(),
                    std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(el)).end(), std::get<Is + 1>(cs.to_be_indexed_).begin())));
 }
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class ExecutionPolicy = default_execution_policy, size_t... Is>
-void copy_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, size_t offset, ExecutionPolicy&& policy = {}) {
+inline void copy_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, size_t offset, ExecutionPolicy&& policy = {}) {
   (...,
    (std::copy(policy, std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(el)).begin(),
               std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(el)).end(), std::get<Is + 1>(cs.to_be_indexed_).begin() + offset)));
@@ -180,7 +180,7 @@ void copy_helper(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is
 
 template <edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class T, class ExecutionPolicy = default_execution_policy,
           size_t... Is>
-void fill_helper_tmp(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, T& Tmp, ExecutionPolicy&& policy = {}) {
+inline void fill_helper_tmp(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...> is, T& Tmp, ExecutionPolicy&& policy = {}) {
   (..., (std::copy(policy, std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(Tmp)).begin(),
                    std::get<Is + 2>(dynamic_cast<typename edge_list_t::base&>(Tmp)).end(), std::get<Is + 1>(cs.to_be_indexed_).begin())));
 }
@@ -207,7 +207,7 @@ void fill_helper_tmp(edge_list_t& el, adjacency_t& cs, std::index_sequence<Is...
  * @param policy The parallel execution policy to use in calls to standard library algorithms called by this function.
  */
 template <int idx, edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class Int, class ExecutionPolicy = default_execution_policy>
-void fill_directed(edge_list_t& el, Int N, adjacency_t& cs, ExecutionPolicy&& policy = {}) {
+inline void fill_directed(edge_list_t& el, Int N, adjacency_t& cs, ExecutionPolicy&& policy = {}) {
 
   auto degree = degrees<idx>(el);
 
@@ -266,7 +266,7 @@ void fill_directed(edge_list_t& el, Int N, adjacency_t& cs, ExecutionPolicy&& po
 
 
 template <int idx, edge_list_graph edge_list_t, class Int, adjacency_list_graph adjacency_t, class ExecutionPolicy = default_execution_policy>
-void fill_undirected(edge_list_t& el, Int N, adjacency_t& cs, ExecutionPolicy&& policy = {}) {
+inline void fill_undirected(edge_list_t& el, Int N, adjacency_t& cs, ExecutionPolicy&& policy = {}) {
   //if the edge is undirected, it means the edge list must be a unipartite graph
   assert(is_unipartite<typename edge_list_t::unipartite_graph_base>::value);
 
@@ -341,7 +341,7 @@ void fill_undirected(edge_list_t& el, Int N, adjacency_t& cs, ExecutionPolicy&& 
 
 
 template <int idx, edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class ExecutionPolicy = default_execution_policy>
-auto fill(edge_list_t& el, adjacency_t& cs, bool sort_adjacency = false, ExecutionPolicy&& policy = {}) {
+inline auto fill(edge_list_t& el, adjacency_t& cs, bool sort_adjacency = false, ExecutionPolicy&& policy = {}) {
   if constexpr (edge_list_t::edge_directedness == nw::graph::directedness::directed) {
     fill_directed<idx>(el, num_vertices(el), cs, policy);
   } else {    // undirected -- this cannot be a bipartite graph
@@ -355,7 +355,7 @@ auto fill(edge_list_t& el, adjacency_t& cs, bool sort_adjacency = false, Executi
 }
 
 template <int idx, edge_list_graph edge_list_t, adjacency_list_graph adjacency_t, class ExecutionPolicy = default_execution_policy>
-auto fill(edge_list_t& el, adjacency_t& cs, directedness dir, bool sort_adjacency = false, ExecutionPolicy&& policy = {}) {
+inline auto fill(edge_list_t& el, adjacency_t& cs, directedness dir, bool sort_adjacency = false, ExecutionPolicy&& policy = {}) {
   if (dir == nw::graph::directedness::directed) {
     fill_directed<idx>(el, num_vertices(el), cs, policy);
   } else {    // undirected -- this cannot be a bipartite graph
@@ -369,7 +369,7 @@ auto fill(edge_list_t& el, adjacency_t& cs, directedness dir, bool sort_adjacenc
 }
 
 template <int idx, edge_list_graph bi_edge_list_t, adjacency_list_graph biadjacency_t, class ExecutionPolicy = default_execution_policy>
-auto fill_biadjacency(bi_edge_list_t& el, biadjacency_t& cs, bool sort_adjacency = false, ExecutionPolicy&& policy = {}) {
+inline auto fill_biadjacency(bi_edge_list_t& el, biadjacency_t& cs, bool sort_adjacency = false, ExecutionPolicy&& policy = {}) {
   if constexpr (bi_edge_list_t::edge_directedness == nw::graph::directedness::directed) {
     fill_directed<idx>(el, num_vertices(el, idx), cs, policy);
   } else {    // undirected -- this cannot be a bipartite graph
@@ -383,7 +383,7 @@ auto fill_biadjacency(bi_edge_list_t& el, biadjacency_t& cs, bool sort_adjacency
 }
 
 template <int idx, edge_list_graph edge_list_t>
-void swap_to_triangular(edge_list_t& el, succession cessor) {
+inline void swap_to_triangular(edge_list_t& el, succession cessor) {
   if (cessor == succession::predecessor) {
     swap_to_triangular<idx, edge_list_t, succession::predecessor>(el);
   } else if (cessor == succession::successor) {
@@ -394,7 +394,7 @@ void swap_to_triangular(edge_list_t& el, succession cessor) {
 }
 
 template <int idx, edge_list_graph edge_list_t>
-void swap_to_triangular(edge_list_t& el, const std::string& cessor = "predecessor") {
+inline void swap_to_triangular(edge_list_t& el, const std::string& cessor = "predecessor") {
   if (cessor == "predecessor") {
     swap_to_triangular<idx, edge_list_t, succession::predecessor>(el);
   } else if (cessor == "successor") {
@@ -405,7 +405,7 @@ void swap_to_triangular(edge_list_t& el, const std::string& cessor = "predecesso
 }
 
 template <int idx, edge_list_graph edge_list_t, succession cessor = succession::predecessor, class ExecutionPolicy = default_execution_policy>
-void swap_to_triangular(edge_list_t& el, ExecutionPolicy&& policy = {}) {
+inline void swap_to_triangular(edge_list_t& el, ExecutionPolicy&& policy = {}) {
 
   if constexpr ((idx == 0 && cessor == succession::predecessor) || (idx == 1 && cessor == succession::successor)) {
     std::for_each(policy, el.begin(), el.end(), [](auto&& f) {
@@ -425,7 +425,7 @@ void swap_to_triangular(edge_list_t& el, ExecutionPolicy&& policy = {}) {
 // Make entries unique -- in place -- remove adjacent redundancies
 // Requires entries to be sorted in both dimensions
 template <edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-void uniq(edge_list_t& el, ExecutionPolicy&& policy = {}) {
+inline void uniq(edge_list_t& el, ExecutionPolicy&& policy = {}) {
 
   auto past_the_end = std::unique(policy, el.begin(), el.end(),
                                   [](auto&& x, auto&& y) { return std::get<0>(x) == std::get<0>(y) && std::get<1>(x) == std::get<1>(y); });
@@ -444,7 +444,7 @@ void remove_self_loops(edge_list_t& el) {
 
 
 template <degree_enumerable_graph Graph, class ExecutionPolicy = default_execution_policy>
-auto degrees(const Graph& graph, ExecutionPolicy&& policy = {}) {
+inline auto degrees(const Graph& graph, ExecutionPolicy&& policy = {}) {
   std::vector<vertex_id_t<Graph>> degree_v(num_vertices(graph));
 
   tbb::parallel_for(tbb::blocked_range(0ul, degree_v.size()), [&](auto&& r) {
@@ -457,7 +457,7 @@ auto degrees(const Graph& graph, ExecutionPolicy&& policy = {}) {
 
 
 template <int d_idx = 0, edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) auto degrees(
+requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) inline auto degrees(
     edge_list_t& el, ExecutionPolicy&& policy = {}) requires(!degree_enumerable_graph<edge_list_t>) {
 
   size_t d_size = 0;
@@ -493,7 +493,7 @@ requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) auto
 
 //for bipartite graph
 template <int d_idx, edge_list_graph edge_list_t, class ExecutionPolicy = default_execution_policy>
-requires(false == is_unipartite<typename edge_list_t::bipartite_graph_base>::value) auto degrees(
+requires(false == is_unipartite<typename edge_list_t::bipartite_graph_base>::value) inline auto degrees(
     edge_list_t& el, ExecutionPolicy&& policy = {}) requires(!degree_enumerable_graph<edge_list_t>) {
 
   size_t d_size        = num_vertices(el, d_idx);
@@ -512,13 +512,13 @@ requires(false == is_unipartite<typename edge_list_t::bipartite_graph_base>::val
 }
 
 template <int idx = 0, edge_list_graph edge_list_t>
-auto perm_by_degree(edge_list_t& el, std::string direction = "ascending") {
+inline auto perm_by_degree(edge_list_t& el, std::string direction = "ascending") {
   auto degree = degrees<idx>(el);
   return perm_by_degree<idx>(el, degree, direction);
 }
 
 template <int idx = 0, edge_list_graph edge_list_t, class Vector, class ExecutionPolicy = default_execution_policy>
-auto perm_by_degree(edge_list_t& el, const Vector& degree, std::string direction = "ascending", ExecutionPolicy&& policy = {}) {
+inline auto perm_by_degree(edge_list_t& el, const Vector& degree, std::string direction = "ascending", ExecutionPolicy&& policy = {}) {
 
   std::vector<typename edge_list_t::vertex_id_type> perm(degree.size());
 
@@ -553,8 +553,8 @@ auto perm_by_degree(edge_list_t& el, const Vector& degree, std::string direction
  * @return the new IDs of the vertices after permutation
  */
 template <edge_list_graph edge_list_t, class Vector, class ExecutionPolicy = default_execution_policy>
-requires(true == is_unipartite<typename edge_list_t::unipartite_graph_base>::value) auto relabel(edge_list_t& el, const Vector& perm,
-                                                                                                 ExecutionPolicy&& policy = {}) {
+requires(true == is_unipartite<typename edge_list_t::unipartite_graph_base>::value)
+inline auto relabel(edge_list_t& el, const Vector& perm, ExecutionPolicy&& policy = {}) {
   std::vector<typename edge_list_t::vertex_id_type> iperm(perm.size());
 
   tbb::parallel_for(tbb::blocked_range(0ul, iperm.size()), [&](auto&& r) {
@@ -583,8 +583,8 @@ requires(true == is_unipartite<typename edge_list_t::unipartite_graph_base>::val
  * @return the new IDs of the vertices after permutation
  */
 template <int idx, edge_list_graph edge_list_t, class Vector, class ExecutionPolicy = default_execution_policy>
-requires(false == is_unipartite<typename edge_list_t::bipartite_graph_base>::value) auto relabel(edge_list_t& el, const Vector& perm,
-                                                                                                 ExecutionPolicy&& policy = {}) {
+requires(false == is_unipartite<typename edge_list_t::bipartite_graph_base>::value)
+inline auto relabel(edge_list_t& el, const Vector& perm, ExecutionPolicy&& policy = {}) {
   std::vector<typename edge_list_t::vertex_id_type> iperm(perm.size());
 
   tbb::parallel_for(tbb::blocked_range(0ul, iperm.size()), [&](auto&& r) {
@@ -607,9 +607,8 @@ requires(false == is_unipartite<typename edge_list_t::bipartite_graph_base>::val
  * @param degree, the degree array
  */
 template <edge_list_graph edge_list_t, class Vector = std::vector<int>>
-requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) void relabel_by_degree(edge_list_t&  el,
-                                                                                                   std::string   direction = "ascending",
-                                                                                                   const Vector& degree = std::vector<int>(0)) {
+requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) 
+inline void relabel_by_degree(edge_list_t& el, std::string direction = "ascending", const Vector& degree = std::vector<int>(0)) {
 
   std::vector<typename edge_list_t::vertex_id_type> perm =
       degree.size() == 0 ? perm_by_degree<0>(el, direction) : perm_by_degree<0>(el, degree, direction);
@@ -629,9 +628,8 @@ requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) void
  * @return the new IDs of the vertices after permutation
  */
 template <int idx, edge_list_graph edge_list_t, class Vector = std::vector<int>>
-requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) auto relabel_by_degree(edge_list_t&  el,
-                                                                                                   std::string   direction = "ascending",
-                                                                                                   const Vector& degree = std::vector<int>(0)) {
+requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) 
+inline auto relabel_by_degree(edge_list_t& el, std::string direction = "ascending", const Vector& degree = std::vector<int>(0)) {
 
   std::vector<typename edge_list_t::vertex_id_type> perm =
       degree.size() == 0 ? perm_by_degree<idx>(el, direction) : perm_by_degree<idx>(el, degree, direction);
@@ -649,7 +647,7 @@ requires(is_unipartite<typename edge_list_t::unipartite_graph_base>::value) auto
  *  Make a map from data to the index value of each element in its container
  */
 template <std::ranges::random_access_range R>
-auto make_index_map(const R& range) {
+inline auto make_index_map(const R& range) {
   using value_type = std::ranges::range_value_t<R>;
 
   std::map<value_type, size_t> the_map;
@@ -664,7 +662,7 @@ auto make_index_map(const R& range) {
  */
 template <class M, std::ranges::random_access_range E, class Edge = decltype(std::tuple_cat(std::tuple<size_t, size_t>())),
           class EdgeList = std::vector<Edge>>
-auto make_plain_edges(M& map, const E& edges) {
+inline auto make_plain_edges(M& map, const E& edges) {
   EdgeList index_edges;
 
   for (Edge&& e : edges) {
@@ -679,7 +677,7 @@ auto make_plain_edges(M& map, const E& edges) {
  */
 template <class M, std::ranges::random_access_range E, class Edge = decltype(std::tuple_cat(std::tuple<size_t, size_t>(), props(E()[0]))),
           class EdgeList = std::vector<Edge>>
-auto make_property_edges(M& map, const E& edges) {
+inline auto make_property_edges(M& map, const E& edges) {
   EdgeList index_edges;
 
   for (auto&& e : edges) {
@@ -693,7 +691,7 @@ auto make_property_edges(M& map, const E& edges) {
  * Make an edge list indexing back to the original data, e.g., vector<tuple<size_t, size_t, size_t>>
  */
 template <class I = std::vector<std::tuple<size_t, size_t, size_t>>, class M, std::ranges::random_access_range E>
-auto make_index_edges(M& map, const E& edges) {
+inline auto make_index_edges(M& map, const E& edges) {
 
   auto index_edges = I();
 
@@ -712,7 +710,7 @@ auto make_index_edges(M& map, const E& edges) {
  *  Make a plain graph from data, e.g., vector<vector<index>>
  */
 template <std::ranges::random_access_range V, std::ranges::random_access_range E, adjacency_list_graph Graph = std::vector<std::vector<size_t>>>
-auto make_plain_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
+inline auto make_plain_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
   auto vertex_map  = make_index_map(vertices);
   auto index_edges = make_plain_edges(vertex_map, edges);
 
@@ -727,7 +725,7 @@ auto make_plain_graph(const V& vertices, const E& edges, bool directed = true, s
  */
 template <std::ranges::random_access_range V, std::ranges::random_access_range E,
           adjacency_list_graph Graph = std::vector<std::vector<std::tuple<size_t, size_t>>>>
-auto make_index_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
+inline auto make_index_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
 
   auto vertex_map  = make_index_map(vertices);
   auto index_edges = make_index_edges(vertex_map, edges);
@@ -743,7 +741,7 @@ auto make_index_graph(const V& vertices, const E& edges, bool directed = true, s
  */
 template <std::ranges::random_access_range V, std::ranges::forward_range E,
           adjacency_list_graph Graph = std::vector<std::vector<decltype(std::tuple_cat(std::make_tuple(size_t{}), props(*(begin(E{})))))>>>
-auto make_property_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
+inline auto make_property_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
 
   auto vertex_map     = make_index_map(vertices);
   auto property_edges = make_property_edges(vertex_map, edges);
@@ -759,7 +757,7 @@ auto make_property_graph(const V& vertices, const E& edges, bool directed = true
  *  Functions for building bipartite graphs
  */
 template <class I = std::vector<std::tuple<size_t, size_t>>, std::ranges::random_access_range V, std::ranges::random_access_range E>
-auto data_to_graph_edge_list(const V& left_vertices, const V& right_vertices, const E& edges) {
+inline auto data_to_graph_edge_list(const V& left_vertices, const V& right_vertices, const E& edges) {
 
   auto left_map  = make_index_map(left_vertices);
   auto right_map = make_index_map(right_vertices);
@@ -779,7 +777,7 @@ auto data_to_graph_edge_list(const V& left_vertices, const V& right_vertices, co
 
 template <std::ranges::random_access_range V1, std::ranges::random_access_range V2, std::ranges::random_access_range E,
           adjacency_list_graph Graph = std::vector<std::vector<decltype(std::tuple_cat(std::make_tuple(size_t{}), props(*(begin(E{})))))>>>
-auto make_plain_bipartite_graph(const V1& left_vertices, const V2& right_vertices, const E& edges, size_t idx = 0) {
+inline auto make_plain_bipartite_graph(const V1& left_vertices, const V2& right_vertices, const E& edges, size_t idx = 0) {
 
   auto index_edges = data_to_graph_edge_list(left_vertices, right_vertices, edges);
   auto graph_size  = idx == 0 ? size(left_vertices) : size(right_vertices);
@@ -792,7 +790,7 @@ auto make_plain_bipartite_graph(const V1& left_vertices, const V2& right_vertice
 
 template <std::ranges::random_access_range V1, std::ranges::random_access_range V2, std::ranges::random_access_range E,
           class Graph = std::vector<std::vector<size_t>>>
-auto make_plain_bipartite_graphs(const V1& left_vertices, const V2& right_vertices, const E& edges) {
+inline auto make_plain_bipartite_graphs(const V1& left_vertices, const V2& right_vertices, const E& edges) {
 
   auto index_edges = data_to_graph_edge_list<>(left_vertices, right_vertices, edges);
 
@@ -807,7 +805,7 @@ auto make_plain_bipartite_graphs(const V1& left_vertices, const V2& right_vertic
 
 template <size_t idx = 0, class Graph = std::vector<std::vector<size_t>>, std::ranges::random_access_range V,
           std::ranges::random_access_range E>
-auto make_bipartite_graph(const V& left_vertices, const V& right_vertices, const E& edges) {
+inline auto make_bipartite_graph(const V& left_vertices, const V& right_vertices, const E& edges) {
 
   auto index_edges = data_to_graph_edge_list(left_vertices, right_vertices, edges);
   auto graph_size  = idx == 0 ? size(left_vertices) : size(right_vertices);
@@ -820,7 +818,7 @@ auto make_bipartite_graph(const V& left_vertices, const V& right_vertices, const
 
 template <std::ranges::random_access_range V, std::ranges::random_access_range E,
           adjacency_list_graph Graph = std::vector<std::vector<decltype(std::tuple_cat(std::make_tuple(size_t{}), props(*(begin(E{})))))>>>
-auto make_bipartite_graphs(const V& left_vertices, const V& right_vertices, const E& edges) {
+inline auto make_bipartite_graphs(const V& left_vertices, const V& right_vertices, const E& edges) {
 
   auto index_edges = data_to_graph_edge_list<>(left_vertices, right_vertices, edges);
 
@@ -834,7 +832,7 @@ auto make_bipartite_graphs(const V& left_vertices, const V& right_vertices, cons
 }
 
 template <class Graph1, class Graph2, class IndexGraph = std::vector<std::vector<std::tuple<size_t, size_t>>>>
-auto join(const Graph1& G, const Graph2& H) {
+inline auto join(const Graph1& G, const Graph2& H) {
 
   std::vector<std::tuple<size_t, size_t, size_t>> s_overlap;
 

--- a/include/nwgraph/compat.hpp
+++ b/include/nwgraph/compat.hpp
@@ -52,7 +52,7 @@ struct graph_traits<std::list<std::tuple<Attributes...>>> {
 
 
 template <typename... Attributes>
-auto tag_invoke(const num_edges_tag, const std::list<std::tuple<Attributes...>>& b) {
+inline auto tag_invoke(const num_edges_tag, const std::list<std::tuple<Attributes...>>& b) {
   return b.size();
 }
 
@@ -69,7 +69,7 @@ struct graph_traits<std::vector<std::tuple<Attributes...>>> {
 
 
 template <typename... Attributes>
-auto tag_invoke(const num_edges_tag, const std::vector<std::tuple<Attributes...>>& b) {
+inline auto tag_invoke(const num_edges_tag, const std::vector<std::tuple<Attributes...>>& b) {
   return b.size();
 }
 

--- a/include/nwgraph/containers/compressed.hpp
+++ b/include/nwgraph/containers/compressed.hpp
@@ -50,12 +50,12 @@
 namespace nw {
 namespace graph {
 
-bool g_debug_compressed = false;
-bool g_time_compressed  = false;
+inline bool g_debug_compressed = false;
+inline bool g_time_compressed  = false;
 
-void debug_compressed(bool flag = true) { g_debug_compressed = flag; }
+inline void debug_compressed(bool flag = true) { g_debug_compressed = flag; }
 
-void time_compressed(bool flag = true) { g_time_compressed = flag; }
+inline void time_compressed(bool flag = true) { g_time_compressed = flag; }
 
 template <typename index_t, typename... Attributes>
 class indexed_struct_of_arrays {
@@ -305,10 +305,10 @@ public:    // fixme
     size_t st_size = indices_.size();
 
     outfile.write(reinterpret_cast<const char*>(magic_), sizeof(magic_));
-    outfile.write(reinterpret_cast<char*>(&N_), sizeof(size_t));
+    outfile.write(reinterpret_cast<char*>(&N_), sizeof(N_));
 
-    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(size_t));
-    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(size_t));
+    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(st_size));
+    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(el_size));
     outfile.write(reinterpret_cast<char*>(indices_.data()), st_size * el_size);
     to_be_indexed_.serialize(outfile);
   }
@@ -324,10 +324,10 @@ public:    // fixme
     size_t st_size = -1;
 
     infile.read(reinterpret_cast<char*>(spell), sizeof(magic_));
-    infile.read(reinterpret_cast<char*>(&N_), sizeof(size_t));
+    infile.read(reinterpret_cast<char*>(&N_), sizeof(N_));
 
-    infile.read(reinterpret_cast<char*>(&st_size), sizeof(size_t));
-    infile.read(reinterpret_cast<char*>(&el_size), sizeof(size_t));
+    infile.read(reinterpret_cast<char*>(&st_size), sizeof(st_size));
+    infile.read(reinterpret_cast<char*>(&el_size), sizeof(el_size));
     indices_.resize(st_size);
     infile.read(reinterpret_cast<char*>(indices_.data()), st_size * el_size);
     to_be_indexed_.deserialize(infile);
@@ -549,13 +549,13 @@ public:    // fixme
 };
 
 template <typename index_t, typename... Attributes>
-auto operator+(typename std::iter_difference_t<typename indexed_struct_of_arrays<index_t, Attributes...>::outer_iterator> n,
-               const typename indexed_struct_of_arrays<index_t, Attributes...>::outer_iterator&                           i) {
+inline auto operator+(typename std::iter_difference_t<typename indexed_struct_of_arrays<index_t, Attributes...>::outer_iterator> n,
+                      const typename indexed_struct_of_arrays<index_t, Attributes...>::outer_iterator&                           i) {
   return i + n;
 }
 
 template <std::signed_integral T, typename I>
-I operator+(T n, const I i) {
+inline I operator+(T n, const I i) {
   return i + n;
 }
 

--- a/include/nwgraph/containers/flattened.hpp
+++ b/include/nwgraph/containers/flattened.hpp
@@ -158,7 +158,7 @@ public:
 
 /// Get a tbb split-able edge range with the passed cutoff.
 template <std::size_t... Attrs>
-flat_range<Attrs...> edges(std::ptrdiff_t cutoff = std::numeric_limits<std::ptrdiff_t>::max()) {
+inline flat_range<Attrs...> edges(std::ptrdiff_t cutoff = std::numeric_limits<std::ptrdiff_t>::max()) {
   flat_iterator<Attrs...> begin = {source(), to_be_indexed_.begin(), indices_.begin(), size(), 0, 0};
   flat_iterator<Attrs...> end   = {source(), to_be_indexed_.begin(),       indices_.begin(),
                                  size(),   index_t(indices_.size() - 1), index_t(to_be_indexed_.size())};
@@ -166,7 +166,7 @@ flat_range<Attrs...> edges(std::ptrdiff_t cutoff = std::numeric_limits<std::ptrd
 }
 
 template <std::size_t... Attrs>
-const_flat_range<Attrs...> edges(std::ptrdiff_t cutoff = std::numeric_limits<std::ptrdiff_t>::max()) const {
+inline const_flat_range<Attrs...> edges(std::ptrdiff_t cutoff = std::numeric_limits<std::ptrdiff_t>::max()) const {
   const_flat_iterator<Attrs...> begin = {source(), to_be_indexed_.begin(), indices_.begin(), size(), 0, 0};
   const_flat_iterator<Attrs...> end   = {source(), to_be_indexed_.begin(),       indices_.begin(),
                                        size(),   index_t(indices_.size() - 1), index_t(to_be_indexed_.size())};

--- a/include/nwgraph/containers/soa.hpp
+++ b/include/nwgraph/containers/soa.hpp
@@ -305,8 +305,8 @@ struct struct_of_arrays : std::tuple<std::vector<Attributes>...> {
   void serialize(std::ostream& outfile, const T& vs) const {
     size_t st_size = vs.size();
     size_t el_size = sizeof(vs[0]);
-    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(size_t));
-    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(size_t));
+    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(st_size));
+    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(el_size));
     outfile.write(reinterpret_cast<const char*>(vs.data()), st_size * el_size);
   }
 
@@ -314,16 +314,16 @@ struct struct_of_arrays : std::tuple<std::vector<Attributes>...> {
   void deserialize(std::istream& infile, T& vs) {
     size_t st_size = -1;
     size_t el_size = -1;
-    infile.read(reinterpret_cast<char*>(&st_size), sizeof(size_t));
-    infile.read(reinterpret_cast<char*>(&el_size), sizeof(size_t));
+    infile.read(reinterpret_cast<char*>(&st_size), sizeof(st_size));
+    infile.read(reinterpret_cast<char*>(&el_size), sizeof(el_size));
     infile.read(reinterpret_cast<char*>(vs.data()), st_size * el_size);
   }
 
   void serialize(std::ostream& outfile) const {
     size_t st_size = std::get<0>(*this).size();
     size_t el_size = std::tuple_size<storage_type>::value;
-    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(size_t));
-    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(size_t));
+    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(st_size));
+    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(el_size));
     std::apply([&](auto&... vs) { (serialize(outfile, vs), ...); }, *this);
   }
 
@@ -335,8 +335,8 @@ struct struct_of_arrays : std::tuple<std::vector<Attributes>...> {
   void deserialize(std::istream& infile) {
     size_t st_size = -1;
     size_t el_size = -1;
-    infile.read(reinterpret_cast<char*>(&st_size), sizeof(size_t));
-    infile.read(reinterpret_cast<char*>(&el_size), sizeof(size_t));
+    infile.read(reinterpret_cast<char*>(&st_size), sizeof(st_size));
+    infile.read(reinterpret_cast<char*>(&el_size), sizeof(el_size));
     resize(st_size);
     std::apply([&](auto&... vs) { (deserialize(infile, vs), ...); }, *this);
   }

--- a/include/nwgraph/containers/zip.hpp
+++ b/include/nwgraph/containers/zip.hpp
@@ -310,12 +310,12 @@ struct zipped : std::tuple<Ranges&...> {
 
 
 template <std::ranges::random_access_range... Ranges>
-zipped<Ranges...> make_zipped(Ranges&... rs) {
+inline zipped<Ranges...> make_zipped(Ranges&... rs) {
   return zipped<Ranges...>(rs...);
 }
 
 template <std::ranges::random_access_range... Ranges>
-zipped<Ranges...> make_zipped(Ranges&&... rs) {
+inline zipped<Ranges...> make_zipped(Ranges&&... rs) {
   return zipped<Ranges...>(rs...);
 }
 
@@ -328,7 +328,7 @@ namespace std {
 
 #if 0
 template <std::ranges::random_access_range... Ranges>
-auto iter_swap(typename nw::graph::zipped<Ranges...>::soa_iterator<false> a, typename nw::graph::zipped<Ranges...>::soa_iterator<false> b) {
+inline auto iter_swap(typename nw::graph::zipped<Ranges...>::soa_iterator<false> a, typename nw::graph::zipped<Ranges...>::soa_iterator<false> b) {
   auto tmp = *a;
   *a = *b;
   *b = *tmp;
@@ -351,14 +351,14 @@ class tuple_size<nw::graph::zipped<Attributes...>> : public std::integral_consta
 namespace std {
 
 template <std::ranges::random_access_range... Ranges, std::size_t... Is>
-void swap(typename nw::graph::zipped<Ranges...>::iterator::reference&& x, typename nw::graph::zipped<Ranges...>::iterator::reference&& y, std::index_sequence<Is...>) {
+inline void swap(typename nw::graph::zipped<Ranges...>::iterator::reference&& x, typename nw::graph::zipped<Ranges...>::iterator::reference&& y, std::index_sequence<Is...>) {
   using std::swap;
   
   (swap(std::get<Is>(x), std::get<Is>(y)), ...);
 }
 
 template <std::ranges::random_access_range... Ranges>
-void swap(typename nw::graph::zipped<Ranges...>::iterator::reference&& x, typename nw::graph::zipped<Ranges...>::iterator::reference&& y) {
+inline void swap(typename nw::graph::zipped<Ranges...>::iterator::reference&& x, typename nw::graph::zipped<Ranges...>::iterator::reference&& y) {
   swap(std::move(x), std::move(y), std::make_index_sequence<sizeof...(Ranges)>());
 }
 

--- a/include/nwgraph/edge_list.hpp
+++ b/include/nwgraph/edge_list.hpp
@@ -47,8 +47,8 @@ namespace graph {
 static bool g_debug_edge_list = false;
 static bool g_time_edge_list  = false;
 
-void debug_edge_list(bool flag = true) { g_debug_edge_list = flag; }
-void time_edge_list(bool flag = true) { g_time_edge_list = flag; }
+inline void debug_edge_list(bool flag = true) { g_debug_edge_list = flag; }
+inline void time_edge_list(bool flag = true) { g_time_edge_list = flag; }
 
 /**
  * Index edge list structure.  This variadic data structure stores edges with their
@@ -274,13 +274,13 @@ template <directedness edge_directedness = directedness::directed, typename... A
 using bi_edge_list = index_edge_list<default_vertex_id_type, bipartite_graph_base, edge_directedness, Attributes...>;
 
 template <std::unsigned_integral vertex_id, typename graph_base_t, directedness direct = directedness::undirected, typename... Attributes>
-auto tag_invoke(const num_edges_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>& b) {
+inline auto tag_invoke(const num_edges_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>& b) {
   return b.num_edges();
 }
 
 // num_vertics CPO, works for both unipartite_graph_base and bipartite_graph_base
 template <std::unsigned_integral vertex_id, typename graph_base_t, directedness direct = directedness::undirected, typename... Attributes>
-auto tag_invoke(const num_vertices_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>& b, int idx = 0) {
+inline auto tag_invoke(const num_vertices_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>& b, int idx = 0) {
   if constexpr (true == is_unipartite<graph_base_t>::value)
     return b.num_vertices()[0]; //for unipartite graph ignore idx value
   else 
@@ -288,12 +288,12 @@ auto tag_invoke(const num_vertices_tag, const index_edge_list<vertex_id, graph_b
 }
 
 template <std::unsigned_integral vertex_id, typename graph_base_t, directedness direct = directedness::undirected, typename... Attributes>
-auto& tag_invoke(const source_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>&, const typename index_edge_list<vertex_id, graph_base_t, direct, Attributes...>::reference e) { 
+inline auto& tag_invoke(const source_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>&, const typename index_edge_list<vertex_id, graph_base_t, direct, Attributes...>::reference e) { 
   return std::get<0>(e);
 }
 
 template <std::unsigned_integral vertex_id, typename graph_base_t, directedness direct = directedness::undirected, typename... Attributes>
-auto& tag_invoke(const target_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>&, const typename index_edge_list<vertex_id, graph_base_t, direct, Attributes...>::reference e) {
+inline auto& tag_invoke(const target_tag, const index_edge_list<vertex_id, graph_base_t, direct, Attributes...>&, const typename index_edge_list<vertex_id, graph_base_t, direct, Attributes...>::reference e) {
   return std::get<1>(e);
 }
 

--- a/include/nwgraph/generators/configuration_model.hpp
+++ b/include/nwgraph/generators/configuration_model.hpp
@@ -27,7 +27,7 @@ namespace graph {
 * dist_min - Minimum value of distribution.  
 * dist_max - Maximum value of distribution.
 */
-std::size_t power_gen (double dist_min, double dist_max) {
+inline std::size_t power_gen (double dist_min, double dist_max) {
   /* Inverse square.  */
   double exponent = -2;
 
@@ -50,7 +50,7 @@ static double standard_exponential_unlikely(bitgen_t *bitgen_state,
     return random_standard_exponential(bitgen_state);
   }
 }
-double random_standard_exponential(bitgen_t *bitgen_state) {
+inline double random_standard_exponential(bitgen_t *bitgen_state) {
   uint64_t ri;
   uint8_t idx;
   double x;
@@ -65,11 +65,12 @@ double random_standard_exponential(bitgen_t *bitgen_state) {
   return standard_exponential_unlikely(bitgen_state, idx, x);
 }
 
-double random_power(bitgen_t *bitgen_state, double a) {
+inline double random_power(bitgen_t *bitgen_state, double a) {
   return pow(1 - exp(-random_standard_exponential(bitgen_state)), 1. / a);
 }
 
-std::vector<std::size_t> power_law_gen(double std::size_t samples)
+// todo: The following line seems problematic
+// std::vector<std::size_t> power_law_gen(double std::size_t samples)
 /*
 * Return a random undirected bipartite graph (in edge_list) from two given degree sequences.
 * The bipartite graph is composed of two partitions. 
@@ -83,7 +84,7 @@ std::vector<std::size_t> power_law_gen(double std::size_t samples)
 * 
 */
 template<class T>
-nw::graph::edge_list<nw::graph::undirected> 
+inline nw::graph::edge_list<nw::graph::undirected> 
 configuration_model(std::vector<T>& deg_seqa, std::vector<T>& deg_seqb, bool contiguous_id_space = false) {
     //validate degree sequences such that their summation are equivalent
     nw::graph::edge_list<nw::graph::undirected> el;

--- a/include/nwgraph/graph_adaptor.hpp
+++ b/include/nwgraph/graph_adaptor.hpp
@@ -50,10 +50,10 @@ public:
 
 
 template <class V>
-bool has_push_back_v = has::has_push_back<V>::value;
+constexpr bool has_push_back_v = has::has_push_back<V>::value;
 
 template <template <class> class V, class T>
-bool has_push_front_v = has::has_push_front<V, T>::value;
+constexpr bool has_push_front_v = has::has_push_front<V, T>::value;
 
 
 template <class T>
@@ -108,7 +108,7 @@ public:
 
 
 template <typename... Ts>
-auto graph_edge(std::tuple<Ts...> t) {
+inline auto graph_edge(std::tuple<Ts...> t) {
   return nth_cdr<1>(t);
 }
 
@@ -116,7 +116,7 @@ auto graph_edge(std::tuple<Ts...> t) {
  * Fill a plain graph from edge list
  */
 template <class EdgeList, class Adjacency>
-void push_back_plain_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, size_t idx) {
+inline void push_back_plain_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, size_t idx) {
   const size_t jdx = (idx + 1) % 2;
 
   for (auto&& e : edge_list) {
@@ -139,7 +139,7 @@ void push_back_plain_fill(const EdgeList& edge_list, Adjacency& adj, bool direct
  * Fill a non-plain graph from edge list
  */
 template <class EdgeList, class Adjacency>
-void push_back_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, size_t idx) {
+inline void push_back_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, size_t idx) {
   const size_t jdx = (idx + 1) % 2;
 
   for (auto&& e : edge_list) {
@@ -164,7 +164,7 @@ void push_back_fill(const EdgeList& edge_list, Adjacency& adj, bool directed, si
  */
 //template <template <class> class I = std::vector, class M, std::ranges::random_access_range E>
 template <edge_list_graph EdgeList, class M, std::ranges::random_access_range E>
-auto make_plain_edges(M& map, const E& edges) {
+inline auto make_plain_edges(M& map, const E& edges) {
   EdgeList index_edges;
 
   for (auto&& e : edges) {
@@ -178,7 +178,7 @@ auto make_plain_edges(M& map, const E& edges) {
  * Make an edge list with properties copied from original data, e.g., vector<tuple<size_t, size_t, props...>>
  */
 template <edge_list_graph EdgeList, class M, std::ranges::random_access_range E>
-auto make_property_edges(M& map, const E& edges) {
+inline auto make_property_edges(M& map, const E& edges) {
   EdgeList index_edges;
 
   for (auto&& e : edges) {
@@ -193,7 +193,7 @@ auto make_property_edges(M& map, const E& edges) {
  *  Make a plain graph from data, e.g., vector<vector<index>>
  */
 template <adjacency_list_graph Graph, std::ranges::random_access_range V, std::ranges::random_access_range E>
-auto make_plain_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
+inline auto make_plain_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
   auto vertex_map  = make_index_map(vertices);
   auto index_edges = make_plain_edges(vertex_map, edges);
 
@@ -207,7 +207,7 @@ auto make_plain_graph(const V& vertices, const E& edges, bool directed = true, s
  *  Make an index graph from data, e.g., vector<vector<tuple<index, index>>>
  */
 template <adjacency_list_graph Graph, std::ranges::random_access_range V, std::ranges::random_access_range E>
-auto make_index_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
+inline auto make_index_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
 
   auto vertex_map  = make_index_map(vertices);
   auto index_edges = make_index_edges(vertex_map, edges);
@@ -223,7 +223,7 @@ auto make_index_graph(const V& vertices, const E& edges, bool directed = true, s
  *  Make a property graph from data, e.g., vector<vector<tuple<index, properties...>>>
  */
 template <adjacency_list_graph Graph, std::ranges::random_access_range V, std::ranges::forward_range E>
-auto make_property_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
+inline auto make_property_graph(const V& vertices, const E& edges, bool directed = true, size_t idx = 0) {
 
   auto vertex_map     = make_index_map(vertices);
   auto property_edges = make_property_edges(vertex_map, edges);
@@ -237,7 +237,7 @@ auto make_property_graph(const V& vertices, const E& edges, bool directed = true
 
 template <adjacency_list_graph Graph, std::ranges::random_access_range V1, std::ranges::random_access_range V2,
           std::ranges::random_access_range E>
-auto make_plain_bipartite_graph(const V1& left_vertices, const V2& right_vertices, const E& edges, size_t idx = 0) {
+inline auto make_plain_bipartite_graph(const V1& left_vertices, const V2& right_vertices, const E& edges, size_t idx = 0) {
 
   auto index_edges = data_to_graph_edge_list(left_vertices, right_vertices, edges);
   auto graph_size  = idx == 0 ? size(left_vertices) : size(right_vertices);
@@ -249,7 +249,7 @@ auto make_plain_bipartite_graph(const V1& left_vertices, const V2& right_vertice
 }
 
 template <adjacency_list_graph Graph, std::ranges::random_access_range V, std::ranges::random_access_range E>
-auto make_bipartite_graphs(const V& left_vertices, const V& right_vertices, const E& edges) {
+inline auto make_bipartite_graphs(const V& left_vertices, const V& right_vertices, const E& edges) {
 
   auto index_edges = data_to_graph_edge_list<>(left_vertices, right_vertices, edges);
 

--- a/include/nwgraph/graph_concepts.hpp
+++ b/include/nwgraph/graph_concepts.hpp
@@ -88,13 +88,13 @@ using inner_reference_t = std::ranges::range_reference_t<inner_range_t<G>>;
 
 
 template <size_t N, typename... Ts>
-auto nth_cdr(std::tuple<Ts...> t) {
+inline auto nth_cdr(std::tuple<Ts...> t) {
   return [&]<std::size_t... Ns>(std::index_sequence<Ns...>) { return std::tuple{std::get<Ns + N>(t)...}; }
   (std::make_index_sequence<sizeof...(Ts) - N>());
 }
 
 template <typename... Ts>
-auto props(std::tuple<Ts...> t) {
+inline auto props(std::tuple<Ts...> t) {
   return nth_cdr<2>(t);
 }
 
@@ -285,23 +285,23 @@ struct graph_traits<G> {
 
 // target CPO
 template <idx_adjacency_list T, class U>
-auto& tag_invoke(const target_tag, const T& graph, const U& e) {
+inline auto& tag_invoke(const target_tag, const T& graph, const U& e) {
   return std::get<0>(e);
 }
 
 template <min_idx_adjacency_list T, class U>
-auto& tag_invoke(const target_tag, const T& graph, const U& e) {
+inline auto& tag_invoke(const target_tag, const T& graph, const U& e) {
   return e;
 }
 
 // num_vertices CPO
 template <idx_adjacency_list T>
-auto tag_invoke(const num_vertices_tag, const T& graph) {
+inline auto tag_invoke(const num_vertices_tag, const T& graph) {
   return (vertex_id_t<T>) graph.size();
 }
 
 template <min_idx_adjacency_list T>
-auto tag_invoke(const num_vertices_tag, const T& graph) {
+inline auto tag_invoke(const num_vertices_tag, const T& graph) {
   return (vertex_id_t<T>) graph.size();
 }
 

--- a/include/nwgraph/io/MatrixMarketFile.hpp
+++ b/include/nwgraph/io/MatrixMarketFile.hpp
@@ -194,7 +194,7 @@ public:
 };
 
 template <typename... Vs>
-auto edges(const MatrixMarketFile& mm, int j, int k) {
+inline auto edges(const MatrixMarketFile& mm, int j, int k) {
   return Range(mm.template at<Vs...>(j), mm.template at<Vs...>(k));
 }
 }    // namespace mmio

--- a/include/nwgraph/io/mmio.hpp
+++ b/include/nwgraph/io/mmio.hpp
@@ -38,7 +38,7 @@
 namespace nw {
 namespace graph {
 
-void mm_fill(std::istream& inputStream, bi_edge_list<directedness::directed>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
+inline void mm_fill(std::istream& inputStream, bi_edge_list<directedness::directed>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
   A.reserve((file_symmetry ? 2 : 1) * nNonzeros);
   A.open_for_push_back();
   for (size_t i = 0; i < nNonzeros; ++i) {
@@ -58,7 +58,7 @@ void mm_fill(std::istream& inputStream, bi_edge_list<directedness::directed>& A,
 }
 
 template <typename T>
-void mm_fill(std::istream& inputStream, bi_edge_list<directedness::directed, T>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
+inline void mm_fill(std::istream& inputStream, bi_edge_list<directedness::directed, T>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
 
   A.reserve((file_symmetry ? 2 : 1) * nNonzeros);
   A.open_for_push_back();
@@ -83,7 +83,7 @@ void mm_fill(std::istream& inputStream, bi_edge_list<directedness::directed, T>&
   A.close_for_push_back();
 }
 
-void mm_fill(std::istream& inputStream, edge_list<directedness::directed>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
+inline void mm_fill(std::istream& inputStream, edge_list<directedness::directed>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
   A.reserve((file_symmetry ? 2 : 1) * nNonzeros);
   A.open_for_push_back();
   for (size_t i = 0; i < nNonzeros; ++i) {
@@ -103,7 +103,7 @@ void mm_fill(std::istream& inputStream, edge_list<directedness::directed>& A, si
 }
 
 template <typename T>
-void mm_fill(std::istream& inputStream, edge_list<directedness::directed, T>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
+inline void mm_fill(std::istream& inputStream, edge_list<directedness::directed, T>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
 
   A.reserve((file_symmetry ? 2 : 1) * nNonzeros);
   A.open_for_push_back();
@@ -128,7 +128,7 @@ void mm_fill(std::istream& inputStream, edge_list<directedness::directed, T>& A,
   A.close_for_push_back();
 }
 
-void mm_fill(std::istream& inputStream, edge_list<directedness::undirected>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
+inline void mm_fill(std::istream& inputStream, edge_list<directedness::undirected>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
 
   A.reserve(nNonzeros);
   A.open_for_push_back();
@@ -149,7 +149,7 @@ void mm_fill(std::istream& inputStream, edge_list<directedness::undirected>& A, 
 }
 
 template <typename T>
-void mm_fill(std::istream& inputStream, edge_list<directedness::undirected, T>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
+inline void mm_fill(std::istream& inputStream, edge_list<directedness::undirected, T>& A, size_t nNonzeros, bool file_symmetry, bool pattern) {
   // assert(file_symmetry);
   A.reserve(nNonzeros);
   A.open_for_push_back();
@@ -169,7 +169,7 @@ void mm_fill(std::istream& inputStream, edge_list<directedness::undirected, T>& 
 }
 
 template <directedness sym, typename... Attributes>
-edge_list<sym, Attributes...> read_mm(std::istream& inputStream) {
+inline edge_list<sym, Attributes...> read_mm(std::istream& inputStream) {
   std::string              string_input;
   bool                     file_symmetry = false;
   std::vector<std::string> header(5);
@@ -208,7 +208,7 @@ edge_list<sym, Attributes...> read_mm(std::istream& inputStream) {
 }
 
 template <directedness sym, typename... Attributes>
-edge_list<sym, Attributes...> read_mm(const std::string& filename) {
+inline edge_list<sym, Attributes...> read_mm(const std::string& filename) {
   std::ifstream inputFile(filename);
 
   edge_list<sym, Attributes...> A = read_mm<sym, Attributes...>(inputFile);
@@ -217,7 +217,7 @@ edge_list<sym, Attributes...> read_mm(const std::string& filename) {
 }
 
 template <directedness sym, typename... Attributes, edge_list_graph edge_list_t>
-edge_list_t read_mm(const std::string& filename) {
+inline edge_list_t read_mm(const std::string& filename) {
   std::ifstream            inputStream(filename);
   std::string              string_input;
   bool                     file_symmetry = false;
@@ -275,7 +275,7 @@ edge_list_t read_mm(const std::string& filename) {
 }
 
 template <typename T>
-auto read_mm_vector(std::istream& inputStream) {
+inline auto read_mm_vector(std::istream& inputStream) {
   std::string string_input;
   bool        file_symmetry = false;
   (void)file_symmetry;    // silence warnings
@@ -329,7 +329,7 @@ auto read_mm_vector(std::istream& inputStream) {
 }
 
 template <typename T>
-auto read_mm_vector(const std::string& filename) {
+inline auto read_mm_vector(const std::string& filename) {
   std::ifstream inputFile(filename);
 
   auto v = read_mm_vector<T>(inputFile);
@@ -337,7 +337,7 @@ auto read_mm_vector(const std::string& filename) {
   return v;
 }
 
-bool is_mm(const std::string& filename) {
+inline bool is_mm(const std::string& filename) {
   std::ifstream            input_stream(filename);
   std::vector<std::string> header(5);
 
@@ -351,7 +351,7 @@ bool is_mm(const std::string& filename) {
   return header[0] == "%%MatrixMarket";
 }
 
-directedness get_mm_symmetry(const std::string& filename) {
+inline directedness get_mm_symmetry(const std::string& filename) {
   std::ifstream            inputStream(filename);
   std::string              string_input;
   std::vector<std::string> header(5);
@@ -375,7 +375,7 @@ directedness get_mm_symmetry(const std::string& filename) {
 }
 
 template <size_t w_idx, directedness sym, typename... Attributes>
-void aos_stream(std::ofstream& outputStream, edge_list<sym, Attributes...> A, const std::string& file_symmetry, std::string& w_type) {
+inline void aos_stream(std::ofstream& outputStream, edge_list<sym, Attributes...> A, const std::string& file_symmetry, std::string& w_type) {
   outputStream << "%%MatrixMarket matrix coordinate " << w_type << " " << file_symmetry << "\n%%\n";
 
   if constexpr (is_unipartite<edge_list<sym, Attributes...>>::value) {
@@ -402,7 +402,7 @@ void aos_stream(std::ofstream& outputStream, edge_list<sym, Attributes...> A, co
 }
 
 template <size_t w_idx = 0, typename idxtype = void, directedness sym, typename... Attributes>
-void write_mm(const std::string& filename, edge_list<sym, Attributes...>& A, const std::string& file_symmetry = "general") {
+inline void write_mm(const std::string& filename, edge_list<sym, Attributes...>& A, const std::string& file_symmetry = "general") {
   if (file_symmetry == "symmetric" && sym == directedness::directed) {
     std::cerr << "cannot save directed matrix as symmetric matrix market" << std::endl;
   }
@@ -418,7 +418,7 @@ void write_mm(const std::string& filename, edge_list<sym, Attributes...>& A, con
 }
 
 template <size_t w_idx, int idx, typename... Attributes>
-void adjacency_stream(std::ofstream& outputStream, adjacency<idx, Attributes...>& A, const std::string& file_symmetry, std::string& w_type) {
+inline void adjacency_stream(std::ofstream& outputStream, adjacency<idx, Attributes...>& A, const std::string& file_symmetry, std::string& w_type) {
   outputStream << "%%MatrixMarket matrix coordinate " << w_type << " " << file_symmetry << "\n%%\n";
 
   outputStream << num_vertices(A) << " " << num_vertices(A) << " "
@@ -434,7 +434,7 @@ void adjacency_stream(std::ofstream& outputStream, adjacency<idx, Attributes...>
 }
 
 template <size_t w_idx = 0, typename idxtype = void, int idx, typename... Attributes>
-void write_mm(const std::string& filename, adjacency<idx, Attributes...>& A, const std::string& file_symmetry = "general") {
+inline void write_mm(const std::string& filename, adjacency<idx, Attributes...>& A, const std::string& file_symmetry = "general") {
   /*if (file_symmetry == "symmetric" && sym == directedness::directed) {
     std::cerr << "cannot save directed matrix as symmetric matrix market" << std::endl;
   }*/
@@ -450,7 +450,7 @@ void write_mm(const std::string& filename, adjacency<idx, Attributes...>& A, con
 }
 
 template <size_t w_idx, int idx, typename... Attributes>
-void adjacency_stream(std::ofstream& outputStream, biadjacency<idx, Attributes...>& A, const std::string& file_symmetry, std::string& w_type) {
+inline void adjacency_stream(std::ofstream& outputStream, biadjacency<idx, Attributes...>& A, const std::string& file_symmetry, std::string& w_type) {
   outputStream << "%%MatrixMarket matrix coordinate " << w_type << " " << file_symmetry << "\n%%\n";
 
   outputStream << num_vertices(A, 0) << " " << num_vertices(A, 1) << " "
@@ -466,7 +466,7 @@ void adjacency_stream(std::ofstream& outputStream, biadjacency<idx, Attributes..
 }
 
 template <size_t w_idx = 0, typename idxtype = void, int idx, typename... Attributes>
-void write_mm(const std::string& filename, biadjacency<idx, Attributes...>& A, const std::string& file_symmetry = "general") {
+inline void write_mm(const std::string& filename, biadjacency<idx, Attributes...>& A, const std::string& file_symmetry = "general") {
   /*if (file_symmetry == "symmetric" && sym == directedness::directed) {
     std::cerr << "cannot save directed matrix as symmetric matrix market" << std::endl;
   }*/
@@ -489,7 +489,7 @@ static size_t block_min(int thread, size_t M, int threads) {
 }
 
 template <typename T>
-std::tuple<size_t, std::array<vertex_id_type, 2>, std::array<vertex_id_type, 2>>
+inline std::tuple<size_t, std::array<vertex_id_type, 2>, std::array<vertex_id_type, 2>>
 par_load_mm(mmio::MatrixMarketFile& mmio, std::vector<std::vector<std::tuple<size_t, size_t, T>>>& sub_lists, std::vector<std::vector<std::tuple<size_t, size_t, T>>>& sub_loops, bool keep_loops, size_t threads) {
   //mmio::MatrixMarketFile mmio(filename);
   std::array<vertex_id_type, 2> Gi_min = {std::numeric_limits<vertex_id_type>::max(), std::numeric_limits<vertex_id_type>::max()};
@@ -552,7 +552,7 @@ par_load_mm(mmio::MatrixMarketFile& mmio, std::vector<std::vector<std::tuple<siz
   return std::tuple(entries, Gi_min, Gi_max);
 }
 
-std::tuple<size_t, std::array<vertex_id_type, 2>, std::array<vertex_id_type, 2>>
+inline std::tuple<size_t, std::array<vertex_id_type, 2>, std::array<vertex_id_type, 2>>
 par_load_mm(mmio::MatrixMarketFile& mmio, std::vector<std::vector<std::tuple<size_t, size_t>>>& sub_lists, std::vector<std::vector<std::tuple<size_t, size_t>>>& sub_loops, bool keep_loops, size_t threads) {
   std::array<vertex_id_type, 2> Gi_min = {std::numeric_limits<vertex_id_type>::max(), std::numeric_limits<vertex_id_type>::max()};
   std::array<vertex_id_type, 2> Gi_max = {0, 0};
@@ -607,7 +607,7 @@ par_load_mm(mmio::MatrixMarketFile& mmio, std::vector<std::vector<std::tuple<siz
 
 
 template <directedness sym, typename... Attributes>
-edge_list<sym, Attributes...> par_read_mm(const std::string& filename, bool keep_loops = true, size_t threads = (size_t) std::thread::hardware_concurrency()) {
+inline edge_list<sym, Attributes...> par_read_mm(const std::string& filename, bool keep_loops = true, size_t threads = (size_t) std::thread::hardware_concurrency()) {
   mmio::MatrixMarketFile mmio(filename);
   if(!mmio.isSymmetric() && sym == undirected) {
     std::cerr << "warning: requested undirected edge list, but mtx file is general" << std::endl;

--- a/include/nwgraph/io/mmio_nist.h
+++ b/include/nwgraph/io/mmio_nist.h
@@ -41,7 +41,7 @@ typedef char MM_typecode[4];
 #define mm_is_skew(typecode)	((typecode)[3]=='K')
 #define mm_is_hermitian(typecode)((typecode)[3]=='H')
 
-int mm_is_valid(MM_typecode matcode)
+inline int mm_is_valid(MM_typecode matcode)
 {
     if (!mm_is_matrix(matcode)) return 0;
     if (mm_is_dense(matcode) && mm_is_pattern(matcode)) return 0;
@@ -104,29 +104,29 @@ int mm_is_valid(MM_typecode matcode)
 
  ***********************************************************************/
 
-char MM_MTX_STR[]        = "matrix";
-char MM_ARRAY_STR[]      = "array";
-char MM_DENSE_STR[]      = "array";
-char MM_COORDINATE_STR[] = "coordinate"; 
-char MM_SPARSE_STR[]     = "coordinate";
-char MM_COMPLEX_STR[]    = "complex";
-char MM_REAL_STR[]       = "real";
-char MM_INT_STR[]        = "integer";
-char MM_GENERAL_STR[]    = "general";
-char MM_SYMM_STR[]       = "symmetric";
-char MM_HERM_STR[]       = "hermitian";
-char MM_SKEW_STR[]       = "skew-symmetric";
-char MM_PATTERN_STR[]    = "pattern";
+inline char MM_MTX_STR[]        = "matrix";
+inline char MM_ARRAY_STR[]      = "array";
+inline char MM_DENSE_STR[]      = "array";
+inline char MM_COORDINATE_STR[] = "coordinate"; 
+inline char MM_SPARSE_STR[]     = "coordinate";
+inline char MM_COMPLEX_STR[]    = "complex";
+inline char MM_REAL_STR[]       = "real";
+inline char MM_INT_STR[]        = "integer";
+inline char MM_GENERAL_STR[]    = "general";
+inline char MM_SYMM_STR[]       = "symmetric";
+inline char MM_HERM_STR[]       = "hermitian";
+inline char MM_SKEW_STR[]       = "skew-symmetric";
+inline char MM_PATTERN_STR[]    = "pattern";
 
 
-char *mm_strdup(const char *s)
+inline char *mm_strdup(const char *s)
 {
 	int len = strlen(s);
 	char *s2 = (char *) malloc((len+1)*sizeof(char));
 	return strcpy(s2, s);
 }
 
-char *mm_typecode_to_str(MM_typecode matcode)
+inline char *mm_typecode_to_str(MM_typecode matcode)
 {
     char buffer[MM_MAX_LINE_LENGTH];
     char *types[4];
@@ -181,7 +181,7 @@ char *mm_typecode_to_str(MM_typecode matcode)
 
 }
 
-int mm_read_banner(FILE *f, MM_typecode *matcode)
+inline int mm_read_banner(FILE *f, MM_typecode *matcode)
 {
     char line[MM_MAX_LINE_LENGTH];
     char banner[MM_MAX_TOKEN_LENGTH];
@@ -266,7 +266,7 @@ int mm_read_banner(FILE *f, MM_typecode *matcode)
     return 0;
 }
 
-int mm_read_mtx_crd_size(FILE *f, int *M, int *N, int *nz )
+inline int mm_read_mtx_crd_size(FILE *f, int *M, int *N, int *nz )
 {
     char line[MM_MAX_LINE_LENGTH];
     int num_items_read;
@@ -296,7 +296,7 @@ int mm_read_mtx_crd_size(FILE *f, int *M, int *N, int *nz )
     return 0;
 }
 
-int mm_read_mtx_array_size(FILE *f, int *M, int *N)
+inline int mm_read_mtx_array_size(FILE *f, int *M, int *N)
 {
     char line[MM_MAX_LINE_LENGTH];
     int num_items_read;

--- a/include/nwgraph/scrap.cpp
+++ b/include/nwgraph/scrap.cpp
@@ -96,16 +96,16 @@ concept edge_list_c = std::ranges::random_access_range<E>&& requires(E e) {
 #endif
 
 template <typename G>
-auto num_edges(const G& g) {
+inline auto num_edges(const G& g) {
   return g.num_edges();
 }
 
 template <typename G>
-auto begin(const G& g) {
+inline auto begin(const G& g) {
   return g.begin();
 }
 
 template <typename G>
-auto num_vertices(const G& g) {
+inline auto num_vertices(const G& g) {
   return g.num_vertices();
 }

--- a/include/nwgraph/util/atomic.hpp
+++ b/include/nwgraph/util/atomic.hpp
@@ -23,7 +23,7 @@ namespace nw {
 namespace graph {
 /// @returns            The loaded value.
 template <std::memory_order order, class T>
-constexpr auto load(T&& t) {
+inline constexpr auto load(T&& t) {
   if constexpr (is_atomic_v<std::decay_t<T>>) {
     return std::forward<T>(t).load(order);
   } else {
@@ -43,7 +43,7 @@ constexpr auto load(T&& t) {
 /// @param            t The variable to store to.
 /// @param            u The value to store.
 template <std::memory_order order, class T, class U>
-constexpr void store(T&& t, U&& u) {
+inline constexpr void store(T&& t, U&& u) {
   if constexpr (is_atomic_v<std::decay_t<T>>) {
     std::forward<T>(t).store(std::forward<U>(u), order);
   } else {
@@ -72,7 +72,7 @@ constexpr void store(T&& t, U&& u) {
 ///                false Otherwise (`u` is updated)
 template <std::memory_order success = std::memory_order_acq_rel, std::memory_order failure = std::memory_order_acquire, class T, class U,
           class V>
-constexpr bool cas(T&& t, U&& u, V&& v) {
+inline constexpr bool cas(T&& t, U&& u, V&& v) {
   if constexpr (is_atomic_v<std::decay_t<T>>) {
     return std::forward<T>(t).compare_exchange_strong(std::forward<U>(u), std::forward<V>(v), success, failure);
   } else {
@@ -88,12 +88,12 @@ constexpr bool cas(T&& t, U&& u, V&& v) {
 ///
 /// @return             The loaded value.
 template <class T>
-constexpr auto acquire(T&& t) {
+inline constexpr auto acquire(T&& t) {
   return load<std::memory_order_acquire>(std::forward<T>(t));
 }
 
 template <class T>
-constexpr auto relaxed(T&& t) {
+inline constexpr auto relaxed(T&& t) {
   return load<std::memory_order_relaxed>(std::forward<T>(t));
 }
 
@@ -105,12 +105,12 @@ constexpr auto relaxed(T&& t) {
 /// @param            t The variable to store to.
 /// @param            u The value to store.
 template <class T, class U>
-constexpr void release(T&& t, U&& u) {
+inline constexpr void release(T&& t, U&& u) {
   store<std::memory_order_release>(std::forward<T>(t), std::forward<U>(u));
 }
 
 template <class T, class U>
-constexpr void relaxed(T&& t, U&& u) {
+inline constexpr void relaxed(T&& t, U&& u) {
   store<std::memory_order_relaxed>(std::forward<T>(t), std::forward<U>(u));
 }
 
@@ -129,7 +129,7 @@ constexpr void relaxed(T&& t, U&& u) {
 ///
 /// @returns            The value of the variable prior to the add operation.
 template <std::memory_order order = std::memory_order_acq_rel, class T, class U>
-constexpr auto fetch_add(T&& t, U&& u) {
+inline constexpr auto fetch_add(T&& t, U&& u) {
   if constexpr (is_atomic_v<std::decay_t<T>>) {
     if constexpr (std::is_floating_point_v<remove_atomic_t<std::decay_t<T>>>) {
       auto&& e = acquire(t);
@@ -153,7 +153,7 @@ constexpr auto fetch_add(T&& t, U&& u) {
 }
 
 template <std::memory_order order = std::memory_order_acq_rel, class T, class U>
-constexpr auto fetch_or(T&& t, U&& u) {
+inline constexpr auto fetch_or(T&& t, U&& u) {
   static_assert(!std::is_floating_point_v<std::decay_t<T>>, "Logical fetch_or invalid for floating point types.");
   if constexpr (is_atomic_v<std::decay_t<T>>) {
     return std::forward<T>(t).fetch_or(std::forward<U>(u), order);

--- a/include/nwgraph/util/demangle.hpp
+++ b/include/nwgraph/util/demangle.hpp
@@ -20,7 +20,7 @@
 namespace nw {
 namespace graph {
 template <class... Args>
-std::string demangle(Args&&... args) {
+inline std::string demangle(Args&&... args) {
   auto        cstr = abi::__cxa_demangle(std::forward<Args>(args)...);
   std::string str(cstr);
   free(cstr);

--- a/include/nwgraph/util/disjoint_set.hpp
+++ b/include/nwgraph/util/disjoint_set.hpp
@@ -37,7 +37,7 @@ namespace graph {
 
 using vertex_id_type = default_vertex_id_type;
 
-vertex_id_type disjoint_find(std::vector<std::pair<vertex_id_type, size_t>>& subsets, vertex_id_type vtx) {
+inline vertex_id_type disjoint_find(std::vector<std::pair<vertex_id_type, size_t>>& subsets, vertex_id_type vtx) {
   vertex_id_type parent = subsets[vtx].first;
   while (parent != subsets[parent].first) {
     parent = subsets[parent].first;
@@ -50,7 +50,7 @@ vertex_id_type disjoint_find(std::vector<std::pair<vertex_id_type, size_t>>& sub
   return parent;
 }
 
-void disjoint_union(std::vector<std::pair<vertex_id_type, size_t>>& subsets, vertex_id_type u, vertex_id_type v) {
+inline void disjoint_union(std::vector<std::pair<vertex_id_type, size_t>>& subsets, vertex_id_type u, vertex_id_type v) {
   vertex_id_type u_root = disjoint_find(subsets, u);
   vertex_id_type v_root = disjoint_find(subsets, v);
 
@@ -66,7 +66,7 @@ void disjoint_union(std::vector<std::pair<vertex_id_type, size_t>>& subsets, ver
   }
 }
 
-bool disjoint_union_find(std::vector<std::pair<vertex_id_type, size_t>>& subsets, vertex_id_type u, vertex_id_type v) {
+inline bool disjoint_union_find(std::vector<std::pair<vertex_id_type, size_t>>& subsets, vertex_id_type u, vertex_id_type v) {
   vertex_id_type u_root = disjoint_find(subsets, u);
   vertex_id_type v_root = disjoint_find(subsets, v);
 

--- a/include/nwgraph/util/intersection_size.hpp
+++ b/include/nwgraph/util/intersection_size.hpp
@@ -48,7 +48,7 @@ namespace graph {
 ///
 /// @returns            The size of the intersected set.
 template <class A, class B, class C, class D, class ExecutionPolicy>
-std::size_t intersection_size(A i, B&& ie, C j, D&& je, ExecutionPolicy&& ep) {
+inline std::size_t intersection_size(A i, B&& ie, C j, D&& je, ExecutionPolicy&& ep) {
   // Custom comparator because we know our iterator operator* produces tuples
   // and we only care about the first value.
   static constexpr auto lt = [](auto&& x, auto&& y) { return std::get<0>(x) < std::get<0>(y); };
@@ -97,7 +97,7 @@ std::size_t intersection_size(A i, B&& ie, C j, D&& je, ExecutionPolicy&& ep) {
 /// @returns            The size of the intersected set.
 template <class R, class S, class ExecutionPolicy,
           std::enable_if_t<std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>, void**> = nullptr>
-std::size_t intersection_size(R&& i, S&& j, ExecutionPolicy&& ep) {
+inline std::size_t intersection_size(R&& i, S&& j, ExecutionPolicy&& ep) {
   return intersection_size(i.begin(), i.end(), j.begin(), j.end(), std::forward<ExecutionPolicy>(ep));
 }
 
@@ -120,7 +120,7 @@ std::size_t intersection_size(R&& i, S&& j, ExecutionPolicy&& ep) {
 /// @returns            The size of the intersected set.
 template <class A, class B, class Range, class ExecutionPolicy,
           std::enable_if_t<std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>, void**> = nullptr>
-std::size_t intersection_size(A&& i, B&& ie, Range&& j, ExecutionPolicy&& ep) {
+inline std::size_t intersection_size(A&& i, B&& ie, Range&& j, ExecutionPolicy&& ep) {
   return intersection_size(std::forward<A>(i), std::forward<B>(ie), j.begin(), j.end(), std::forward<ExecutionPolicy>(ep));
 }
 
@@ -142,7 +142,7 @@ std::size_t intersection_size(A&& i, B&& ie, Range&& j, ExecutionPolicy&& ep) {
 ///
 /// @returns            The size of the intersected set.
 template <class A, class B, class C, class D, std::enable_if_t<!std::is_execution_policy_v<std::decay_t<D>>, void**> = nullptr>
-std::size_t intersection_size(A&& i, B&& ie, C&& j, D&& je) {
+inline std::size_t intersection_size(A&& i, B&& ie, C&& j, D&& je) {
   return intersection_size(std::forward<A>(i), std::forward<B>(ie), std::forward<C>(j), std::forward<D>(je), std::execution::seq);
 }
 
@@ -159,7 +159,7 @@ std::size_t intersection_size(A&& i, B&& ie, C&& j, D&& je) {
 ///
 /// @returns            The size of the intersected set.
 template <class R, class S>
-std::size_t intersection_size(R&& i, S&& j) {
+inline std::size_t intersection_size(R&& i, S&& j) {
   return intersection_size(i.begin(), i.end(), j.begin(), j.end(), std::execution::seq);
 }
 
@@ -180,7 +180,7 @@ std::size_t intersection_size(R&& i, S&& j) {
 ///
 /// @returns            The size of the intersected set.
 template <class A, class B, class Range, std::enable_if_t<!std::is_execution_policy_v<std::decay_t<Range>>, void**> = nullptr>
-std::size_t intersection_size(A&& i, B&& ie, Range&& j) {
+inline std::size_t intersection_size(A&& i, B&& ie, Range&& j) {
   return intersection_size(std::forward<A>(i), std::forward<B>(ie), j.begin(), j.end(), std::execution::seq);
 }
 }    // namespace graph

--- a/include/nwgraph/util/make_priority_queue.hpp
+++ b/include/nwgraph/util/make_priority_queue.hpp
@@ -23,7 +23,7 @@ namespace graph {
 /// @returns            A `std::priority_queue` instantiated with the proper
 ///                     types.
 template <class T, class Container, class Compare>
-constexpr auto make_priority_queue(Compare&& compare) {
+inline constexpr auto make_priority_queue(Compare&& compare) {
   using PQ = std::priority_queue<T, Container, std::decay_t<Compare>>;
   return PQ{std::forward<Compare>(compare)};
 }
@@ -42,7 +42,7 @@ constexpr auto make_priority_queue(Compare&& compare) {
 /// @returns            A `std::priority_queue` wrapping a `std::vector<T>` that
 ///                     uses the passed `compare` operation.
 template <class T, class Compare>
-constexpr auto make_priority_queue(Compare&& compare) {
+inline constexpr auto make_priority_queue(Compare&& compare) {
   return make_priority_queue<T, std::vector<T>>(std::forward<Compare>(compare));
 }
 }    // namespace graph

--- a/include/nwgraph/util/parallel_for.hpp
+++ b/include/nwgraph/util/parallel_for.hpp
@@ -32,7 +32,7 @@ namespace graph {
 ///       op(unpack(i)...) if `i` is a tuple type
 /// parallel_for_inner(*i) otherwise
 template <class Op, class It>
-auto parallel_for_inner(Op&& op, It&& i) {
+inline auto parallel_for_inner(Op&& op, It&& i) {
   if constexpr (is_tuple_v<std::decay_t<It>>) {
     return std::apply([&](auto&&... args) { return std::forward<Op>(op)(std::forward<decltype(args)>(args)...); }, std::forward<It>(i));
   } else if constexpr (std::is_integral_v<std::decay_t<It>>) {
@@ -54,7 +54,7 @@ auto parallel_for_inner(Op&& op, It&& i) {
 /// @param        range The range to process.
 /// @param           op The operator to evaluate.
 template <class Range, class Op>
-void parallel_for_sequential(Range&& range, Op&& op) {
+inline void parallel_for_sequential(Range&& range, Op&& op) {
   for (auto &&i = range.begin(), e = range.end(); i != e; ++i) {
     parallel_for_inner(op, i);
   }
@@ -75,7 +75,7 @@ void parallel_for_sequential(Range&& range, Op&& op) {
 /// @returns            The result of `reduce(op(i), ...)` for all `i` in
 ///                     `range`.
 template <class Range, class Op, class Reduce, class T>
-auto parallel_for_sequential(Range&& range, Op&& op, Reduce&& reduce, T init) {
+inline auto parallel_for_sequential(Range&& range, Op&& op, Reduce&& reduce, T init) {
   for (auto &&i = range.begin(), e = range.end(); i != e; ++i) {
     init = reduce(init, parallel_for_inner(op, i));
   }
@@ -95,7 +95,7 @@ auto parallel_for_sequential(Range&& range, Op&& op, Reduce&& reduce, T init) {
 /// @param        range The range to process.
 /// @param           op The operator to evaluate.
 template <class Range, class Op>
-void parallel_for(Range&& range, Op&& op) {
+inline void parallel_for(Range&& range, Op&& op) {
   if (range.is_divisible()) {
     tbb::parallel_for(std::forward<Range>(range),
                       [&](auto&& sub) { parallel_for_sequential(std::forward<decltype(sub)>(sub), std::forward<Op>(op)); });
@@ -123,7 +123,7 @@ void parallel_for(Range&& range, Op&& op) {
 /// @returns            The result of `reduce(op(i), ...)` for all `i` in
 ///                     `range`.
 template <class Range, class Op, class Reduce, class T>
-auto parallel_reduce(Range&& range, Op&& op, Reduce&& reduce, T init) {
+inline auto parallel_reduce(Range&& range, Op&& op, Reduce&& reduce, T init) {
   if (range.is_divisible()) {
     return tbb::parallel_reduce(
         std::forward<Range>(range), init,

--- a/include/nwgraph/util/print_types.hpp
+++ b/include/nwgraph/util/print_types.hpp
@@ -18,7 +18,7 @@ template <class... Ts>
 struct print_types_t;
 
 template <class... Ts>
-constexpr auto print_types(Ts...) {
+inline constexpr auto print_types(Ts...) {
   return print_types_t<Ts...>{};
 }
 

--- a/include/nwgraph/util/provenance.hpp
+++ b/include/nwgraph/util/provenance.hpp
@@ -23,17 +23,17 @@
 namespace nw {
 namespace graph {
 
-std::string& ltrim(std::string& str, const std::string& chars = "\t\n\v\f\r ") {
+inline std::string& ltrim(std::string& str, const std::string& chars = "\t\n\v\f\r ") {
   str.erase(0, str.find_first_not_of(chars));
   return str;
 }
 
-std::string& rtrim(std::string& str, const std::string& chars = "\t\n\v\f\r ") {
+inline std::string& rtrim(std::string& str, const std::string& chars = "\t\n\v\f\r ") {
   str.erase(str.find_last_not_of(chars) + 1);
   return str;
 }
 
-std::string& trim(std::string& str, const std::string& chars = "\t\n\v\f\r ") { return ltrim(rtrim(str, chars), chars); }
+inline std::string& trim(std::string& str, const std::string& chars = "\t\n\v\f\r ") { return ltrim(rtrim(str, chars), chars); }
 
 class provenance {
 public:

--- a/include/nwgraph/util/proxysort.hpp
+++ b/include/nwgraph/util/proxysort.hpp
@@ -34,7 +34,7 @@ namespace util {
 //}
 
 template <typename ThingToSort, typename Comparator, typename IntT, class ExecutionPolicy = std::execution::parallel_unsequenced_policy>
-void proxysort(const ThingToSort& x, std::vector<IntT>& perm, Comparator comp = std::less<IntT>(), ExecutionPolicy policy = {}) {
+inline void proxysort(const ThingToSort& x, std::vector<IntT>& perm, Comparator comp = std::less<IntT>(), ExecutionPolicy policy = {}) {
   assert(perm.size() == x.size());
 
 #if 0
@@ -58,7 +58,7 @@ void proxysort(const ThingToSort& x, std::vector<IntT>& perm, Comparator comp = 
 }
 
 template <typename IntT = uint32_t, typename Comparator, typename ThingToSort, class ExecutionPolicy = std::execution::parallel_unsequenced_policy>
-auto proxysort(const ThingToSort& x, Comparator comp = std::less<IntT>(), ExecutionPolicy policy = {}) {
+inline auto proxysort(const ThingToSort& x, Comparator comp = std::less<IntT>(), ExecutionPolicy policy = {}) {
   std::vector<IntT> perm(x.size());
   proxysort(x, perm, comp, policy);
   return perm;

--- a/include/nwgraph/util/timer.hpp
+++ b/include/nwgraph/util/timer.hpp
@@ -45,9 +45,9 @@ protected:
 };
 
 
-using seconds_timer = timer<std::chrono::seconds>;
-using ms_timer = timer<std::chrono::milliseconds>;
-using us_timer = timer<std::chrono::microseconds>;
+using seconds_timer = timer<std::chrono::duration<double>>;
+using ms_timer = timer<std::chrono::duration<double, std::ratio<1, 1'000>>>;
+using us_timer = timer<std::chrono::duration<double, std::ratio<1, 1'000'000>>>;
 
 class empty_timer {
 public:
@@ -69,7 +69,7 @@ public:
   }
 };
 
-std::ostream& operator<<(std::ostream& os, const seconds_timer& t) {
+inline std::ostream& operator<<(std::ostream& os, const seconds_timer& t) {
   std::string name = t.name();
   if (t.name() != "") {
     os << "(" << t.name() << ") ";
@@ -78,7 +78,7 @@ std::ostream& operator<<(std::ostream& os, const seconds_timer& t) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const ms_timer& t) {
+inline std::ostream& operator<<(std::ostream& os, const ms_timer& t) {
   std::string name = t.name();
   if (t.name() != "") {
     os << "(" << t.name() << ") ";
@@ -88,7 +88,7 @@ std::ostream& operator<<(std::ostream& os, const ms_timer& t) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const us_timer& t) {
+inline std::ostream& operator<<(std::ostream& os, const us_timer& t) {
   std::string name = t.name();
   if (t.name() != "") {
     os << "(" << t.name() << ") ";

--- a/include/nwgraph/util/tuple_hack.hpp
+++ b/include/nwgraph/util/tuple_hack.hpp
@@ -36,7 +36,7 @@ namespace std {
 
 #if 1
 template <class... Ts> requires (nw::graph::is_swappable<Ts>::value && ...)
-void swap(std::tuple<Ts...>&& x, std::tuple<Ts...>&& y) 
+inline void swap(std::tuple<Ts...>&& x, std::tuple<Ts...>&& y) 
 {
     using std::swap;
     using std::get;
@@ -46,13 +46,13 @@ void swap(std::tuple<Ts...>&& x, std::tuple<Ts...>&& y)
 }
 #else
 template <class... Ts, std::size_t... Is>
-void swap(std::tuple<Ts&...>&& x, std::tuple<Ts&...>&& y, std::index_sequence<Is...>) {
+inline void swap(std::tuple<Ts&...>&& x, std::tuple<Ts&...>&& y, std::index_sequence<Is...>) {
 
   (std::swap(std::get<Is>(x), std::get<Is>(y)), ...);
 }
 
 template <class... Ts>
-void swap(std::tuple<Ts&...>&& x, std::tuple<Ts&...>&& y) {
+inline void swap(std::tuple<Ts&...>&& x, std::tuple<Ts&...>&& y) {
   
   swap(std::move(x), std::move(y), std::make_index_sequence<sizeof...(Ts)>());
 }

--- a/include/nwgraph/util/util.hpp
+++ b/include/nwgraph/util/util.hpp
@@ -147,7 +147,7 @@ struct counter    // : public std::iterator<std::output_iterator_tag, std::ptrdi
 ///
 /// @returns            A tuple composed of the proper elements from `t`.
 template <std::size_t... Is, class Tuple, class = std::enable_if_t<is_tuple_v<std::decay_t<Tuple>>>>
-constexpr auto select(Tuple&& t) -> std::tuple<std::tuple_element_t<Is, std::decay_t<Tuple>>...> {
+inline constexpr auto select(Tuple&& t) -> std::tuple<std::tuple_element_t<Is, std::decay_t<Tuple>>...> {
   static_assert(((Is < std::tuple_size_v<std::decay_t<Tuple>>)&&...), "tuple index out of range during select");
   return {std::forward<std::tuple_element_t<Is, std::decay_t<Tuple>>>(std::get<Is>(std::forward<Tuple>(t)))...};
 }
@@ -168,39 +168,39 @@ inline constexpr auto null_vertex_v() {
 
 template <typename InputIterator, typename RandomAccessIterator,
           typename = std::enable_if_t<nw::graph::is_tuple_v<typename InputIterator::value_type>>>
-void histogram(InputIterator first, InputIterator last, RandomAccessIterator o_first, RandomAccessIterator o_last, size_t idx = 0) {
+inline void histogram(InputIterator first, InputIterator last, RandomAccessIterator o_first, RandomAccessIterator o_last, size_t idx = 0) {
   std::fill(o_first, o_last, 0);
   std::for_each(first, last, [&](auto& i) { o_first[std::get<idx>(i)]++; });
 };
 
 template <typename InputIterator, typename RandomAccessIterator>
-void histogram(InputIterator first, InputIterator last, RandomAccessIterator o_first, RandomAccessIterator o_last) {
+inline void histogram(InputIterator first, InputIterator last, RandomAccessIterator o_first, RandomAccessIterator o_last) {
   std::fill(o_first, o_last, 0);
   std::for_each(first, last, [&](auto& i) { o_first[i]++; });
 };
 
 template <typename T>
-constexpr typename std::underlying_type<T>::type idx(T value) {
+inline constexpr typename std::underlying_type<T>::type idx(T value) {
   return static_cast<typename std::underlying_type<T>::type>(value);
 }
 
 template <typename OuterIter>
-auto get_source(OuterIter& outer) {
+inline auto get_source(OuterIter& outer) {
   return outer.get_index();
 };
 
 template <typename InnerIter>
-auto get_target(InnerIter& inner) {
+inline auto get_target(InnerIter& inner) {
   return std::get<0>(*inner);
 };
 
 template <size_t Idx, typename Iterator>
-auto property(Iterator& inner) {
+inline auto property(Iterator& inner) {
   return std::get<Idx>(*inner);
 }
 
 template <size_t Idx, typename Iterator>
-auto property_ptr(Iterator& inner) {
+inline auto property_ptr(Iterator& inner) {
   return &std::get<Idx>(*inner);
 }
 

--- a/include/nwgraph/vofos.hpp
+++ b/include/nwgraph/vofos.hpp
@@ -118,7 +118,7 @@ auto tag_invoke(const num_vertices_tag, index_adj_flist<idx, vertex_id, Attribut
 #if 0
 
 template <typename... Attributes>
-graph_traits<std::vector<std::forward_list<std::tuple<Attributes...>>>>::num_vertices_type
+inline graph_traits<std::vector<std::forward_list<std::tuple<Attributes...>>>>::num_vertices_type
 num_vertices(const typename std::vector<std::forward_list<std::tuple<Attributes...>>>& g) {
   return { g.size() };
 }

--- a/include/nwgraph/volos.hpp
+++ b/include/nwgraph/volos.hpp
@@ -111,14 +111,14 @@ struct graph_traits<index_adj_list<idx, vertex_id, Attributes...>> {
 };
 
 template <int idx, std::unsigned_integral vertex_id, typename... Attributes>
-auto tag_invoke(const num_vertices_tag, index_adj_list<idx, vertex_id, Attributes...>& b) {
+inline auto tag_invoke(const num_vertices_tag, index_adj_list<idx, vertex_id, Attributes...>& b) {
   return b.num_vertices()[0];
 }
 
 #if 0
 
 template <typename... Attributes>
-graph_traits<std::vector<std::list<std::tuple<Attributes...>>>>::num_vertices_type
+inline graph_traits<std::vector<std::list<std::tuple<Attributes...>>>>::num_vertices_type
 num_vertices(const typename std::vector<std::list<std::tuple<Attributes...>>>& g) {
   return { g.size() };
 }


### PR DESCRIPTION
Changes:
1. Adds `inline` keyword for functions to prevent link error;
2. Fixes the bug in current (de-)serialization code that `sizeof(N_)` may mismatch with `sizeof(size_t)` since `N_` is of type `index_t`;
3. Changes the representation type of duration in `nw::util::timer` to `double` for more precision (especially for `seconds_timer`)

Example of 2. bug in (de-)serialization:
```
  void serialize(std::ostream& outfile) {
    size_t el_size = sizeof(indices_[0]);
    size_t st_size = indices_.size();

    outfile.write(reinterpret_cast<const char*>(magic_), sizeof(magic_));
    outfile.write(reinterpret_cast<char*>(&N_), sizeof(size_t)); // <------ BUG HERE !

    outfile.write(reinterpret_cast<char*>(&st_size), sizeof(size_t));
    outfile.write(reinterpret_cast<char*>(&el_size), sizeof(size_t));
    outfile.write(reinterpret_cast<char*>(indices_.data()), st_size * el_size);
    to_be_indexed_.serialize(outfile);
  }
```