### PR TITLE
Fix const correctness in index_adjacency::serialize()

### DIFF
--- a/include/nwgraph/adjacency.hpp
+++ b/include/nwgraph/adjacency.hpp
@@ -170,10 +170,10 @@ public:
   };
   /**
    * @brief Serialize the index_adjacency into binary file.
-   * 
+   *
    * @param outfile_name The output file name.
    */
-  void serialize(const std::string& outfile_name) const {
+  void serialize(const std::string& outfile_name) {
     std::ofstream out_file(outfile_name, std::ofstream::binary);
     unipartite_graph_base::serialize(out_file);
     base::serialize(out_file);


### PR DESCRIPTION
The serialize() method in index_adjacency (unipartite version) was incorrectly marked const, but it calls base::serialize(out_file) which is not a const method (defined in indexed_struct_of_arrays).

This caused compilation errors when trying to serialize graphs:
  error: no matching member function for call to 'serialize'
  note: candidate function not viable: 'this' argument has type
        'const nw::graph::index_adjacency<...>', but method is not
        marked const

The bipartite version at line 302 is already correct (no const). This fix makes the unipartite version consistent.

Fixes compilation when using serialize() on adjacency graphs.