### PR TITLE
Fix postfix SoA iterator movement

### DIFF
--- a/include/nwgraph/containers/soa.hpp
+++ b/include/nwgraph/containers/soa.hpp
@@ -141,11 +141,15 @@ struct struct_of_arrays : std::tuple<std::vector<Attributes>...> {
     auto operator<=>(const soa_iterator&) const = default;
 
     soa_iterator operator++(int) {
-      return soa_iterator { i_++, soa_ };
+      auto previous = *this;
+      ++(*this);
+      return previous;
     }
 
     soa_iterator operator--(int) {
-      return soa_iterator { i_--, soa_ };
+      auto previous = *this;
+      --(*this);
+      return previous;
     }
 
     soa_iterator& operator++() {

--- a/include/nwgraph/containers/zip.hpp
+++ b/include/nwgraph/containers/zip.hpp
@@ -120,10 +120,14 @@ struct zipped : std::tuple<Ranges&...> {
     auto operator<=>(const soa_iterator&) const = default;
 
     soa_iterator operator++(int) {
-      return soa_iterator(i_++, soa_);
+      auto previous = *this;
+      ++(*this);
+      return previous;
     }
     soa_iterator operator--(int) {
-      return soa_iterator(i_--, soa_);
+      auto previous = *this;
+      --(*this);
+      return previous;
     }
 
     soa_iterator& operator++() {

--- a/test/soa_test.cpp
+++ b/test/soa_test.cpp
@@ -124,6 +124,33 @@ TEST_CASE("struct of arrays", "[soa]") {
     test_assignment<2>(h, 3);
     test_assignment<3>(h, 3);
   }
+
+  SECTION("postfix iterator movement returns the previous position") {
+    struct_of_arrays<size_t, size_t> values {
+      { 1, 10 },
+      { 2, 20 },
+      { 3, 30 }
+    };
+
+    auto current  = values.begin();
+    auto previous = current++;
+    REQUIRE(std::get<0>(*previous) == 1);
+    REQUIRE(std::get<0>(*current) == 2);
+
+    auto later = current--;
+    REQUIRE(std::get<1>(*later) == 20);
+    REQUIRE(std::get<1>(*current) == 10);
+
+    const auto& const_values   = values;
+    auto        const_current  = const_values.begin();
+    auto        const_previous = const_current++;
+    REQUIRE(std::get<0>(*const_previous) == 1);
+    REQUIRE(std::get<0>(*const_current) == 2);
+
+    auto const_later = const_current--;
+    REQUIRE(std::get<1>(*const_later) == 20);
+    REQUIRE(std::get<1>(*const_current) == 10);
+  }
 }
 
 template <typename SOA>

--- a/test/zip_test.cpp
+++ b/test/zip_test.cpp
@@ -132,6 +132,31 @@ TEST_CASE("Zipped iterator operations", "[zip]") {
     REQUIRE(x == 2);
     REQUIRE(y == 5);
   }
+
+  SECTION("Postfix movement returns the previous position") {
+    std::vector<int> a = { 1, 2, 3 };
+    std::vector<int> b = { 10, 20, 30 };
+    auto             z = make_zipped(a, b);
+
+    auto current  = z.begin();
+    auto previous = current++;
+    REQUIRE(std::get<0>(*previous) == 1);
+    REQUIRE(std::get<0>(*current) == 2);
+
+    auto later = current--;
+    REQUIRE(std::get<1>(*later) == 20);
+    REQUIRE(std::get<1>(*current) == 10);
+
+    const auto& const_z        = z;
+    auto        const_current  = const_z.begin();
+    auto        const_previous = const_current++;
+    REQUIRE(std::get<0>(*const_previous) == 1);
+    REQUIRE(std::get<0>(*const_current) == 2);
+
+    auto const_later = const_current--;
+    REQUIRE(std::get<1>(*const_later) == 20);
+    REQUIRE(std::get<1>(*const_current) == 10);
+  }
 }
 
 TEST_CASE("Zipped empty and resize", "[zip]") {


### PR DESCRIPTION
## Summary
- fix postfix increment and decrement in struct-of-arrays iterators
- apply the same correction to zipped iterators
- add mutable and const regression coverage for returned and current positions

## Testing
- GCC 15 Release build
- targeted struct-of-arrays and zipped iterator tests
- full upstream CTest suite: 189/189 passed